### PR TITLE
Don't mess up the CLI output with `console.log`s (`console.warn`s, etc) from tests

### DIFF
--- a/src/env/node.js
+++ b/src/env/node.js
@@ -118,17 +118,22 @@ export default {
 		render(root, options);
 
 		if (root.stats.pending === 0) {
+			logUpdate.clear();
+
+			let {messages, originalConsole} = interceptedConsole;
+			restoreConsole(originalConsole);
+
+			// Replay all the suppressed messages from the tests
+			for (let message of messages) {
+				let {args, method} = message;
+				console[method](...args);
+			}
 
 			let hint = `
 Use <b>↑</b> and <b>↓</b> arrow keys to navigate groups of tests, <b>→</b> and <b>←</b> to expand and collapse them respectively.
 Press <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
 `;
 			hint = format(hint);
-
-			let {messages, originalConsole} = interceptedConsole;
-			restoreConsole(originalConsole);
-
-			logUpdate.clear();
 			console.log(hint);
 
 			readline.emitKeypressEvents(process.stdin);

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -10,7 +10,7 @@ import { globSync } from 'glob';
 
 // Internal modules
 import format from "../format-console.js";
-import { getType } from '../util.js';
+import { getType, interceptConsole, restoreConsole } from '../util.js';
 
 // Recursively traverse a subtree starting from `node` and make (only) groups of tests collapsible
 function makeCollapsible (node) {
@@ -79,6 +79,8 @@ async function getTestsIn (dir) {
 	})));
 }
 
+let interceptedConsole;
+
 export default {
 	name: "Node.js",
 	defaultOptions: {
@@ -109,6 +111,7 @@ export default {
 	},
 	setup () {
 		process.env.NODE_ENV = "test";
+		interceptedConsole = interceptConsole();
 	},
 	done (result, options, event, root) {
 		makeCollapsible(root)
@@ -121,6 +124,9 @@ Use <b>↑</b> and <b>↓</b> arrow keys to navigate groups of tests, <b>→</b>
 Press <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
 `;
 			hint = format(hint);
+
+			let {messages, originalConsole} = interceptedConsole;
+			restoreConsole(originalConsole);
 
 			logUpdate.clear();
 			console.log(hint);

--- a/src/util.js
+++ b/src/util.js
@@ -182,3 +182,27 @@ export function subsetTests (test, path) {
 
 	return tests;
 }
+
+export function interceptConsole () {
+	let messages = [];
+
+	function getOriginalConsole () {
+		const methods = ["log", "warn", "error", "info"];
+		let originalConsole = {};
+
+		for (let method of methods) {
+			originalConsole[method] = console[method];
+			console[method] = (...args) => messages.push({args, method});
+		}
+
+		return originalConsole;
+	}
+
+	return {messages, originalConsole: getOriginalConsole()};
+}
+
+export function restoreConsole (originalConsole) {
+	for (let method in originalConsole) {
+		console[method] = originalConsole[method];
+	}
+}


### PR DESCRIPTION
Fixes #26 

- Intercept the console before running the tests and restore it after all the tests are finished.

- We can replay all the intercepted messages later if needed. Do we need a separate option for this?