### PR TITLE
Interactive CLI improvements

### DIFF
--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -365,7 +365,7 @@ ${ this.error.stack }`);
 
 		if (this.tests) {
 			ret = new String(ret);
-			ret.children = this.tests.filter(t => t.stats.fail + t.stats.pending + t.stats.skipped > 0)
+			ret.children = this.tests.filter(t => o?.verbose || t.stats.fail + t.stats.pending + t.stats.skipped > 0)
 				                     .flatMap(t => t.toString(o)).filter(Boolean);
 			ret.collapsed = ret.children.length ? this.collapsed : undefined;
 			ret.highlighted = this.highlighted;

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -16,16 +16,17 @@ import { getType, interceptConsole, restoreConsole } from '../util.js';
 // Consider the `expand` option, which specifies which groups should be expanded by default.
 // For example, `expand = "fail skipped"` will expand groups that contain failed or skipped tests.
 function makeCollapsible (node, { expand = "fail", verbose } = {}) {
+function makeCollapsible (node, options = {}) {
 	if (node.tests?.length) {
-		let options = [...new Set((expand).split(/\s+/))];
+		let expand = [...new Set((options.expand ?? "fail").split(/\s+/))];
 
 		// All groups are collapsed by default or if the verbose option is specified.
 		// Otherwise, it will be expanded if a group contains tests, because of which
 		// the group should be expanded (e.g., failed tests).
-		node.collapsed = node.parent && !verbose && options.some(o => node.stats[o] > 0) ? false : true;
+		node.collapsed = node.parent && !options.verbose && expand.some(o => node.stats[o] > 0) ? false : true;
 
 		for (let test of node.tests) {
-			makeCollapsible(test, { expand, verbose });
+			makeCollapsible(test, options);
 		}
 	}
 }

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -52,11 +52,18 @@ function getVisibleGroups (node, options, groups = []) {
 
 function getTree (msg, i) {
 	if (msg.collapsed !== undefined) {
+		const icons = {
+			collapsed: "▷",
+			expanded: "▽",
+			highlightedCollapsed: "▶︎",
+			highlightedExpanded: "▼",
+		};
+
 		let {collapsed, highlighted, children} = msg;
 
-		let icon = collapsed ? "▷" : "▽";
+		let icon = collapsed ? icons.collapsed : icons.expanded;
 		if (highlighted) {
-			icon = `<c green><b>${ collapsed ? "▶︎" : "▼" }</b></c>`;
+			icon = `<c green><b>${ collapsed ? icons.highlightedCollapsed : icons.highlightedExpanded }</b></c>`;
 			msg = `<b>${ msg }</b>`;
 		}
 		msg = icon + " " + msg;

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -12,14 +12,19 @@ import { globSync } from 'glob';
 import format from "../format-console.js";
 import { getType, interceptConsole, restoreConsole } from '../util.js';
 
-// Recursively traverse a subtree starting from `node` and make (only) groups of tests collapsible.
-// Consider the `expand` option, which specifies which groups should be expanded by default.
-// For example, `expand = "fail skipped"` will expand groups that contain failed or skipped tests.
-function makeCollapsible (node, { expand = "fail", verbose } = {}) {
+/**
+ * Recursively traverse a subtree starting from `node` and make (only) groups of tests collapsible.
+ * @param {object} node
+ * @param {string} [options.expand = "fail"] Space-separated list of possible test results: `pass`, `fail`, or `skipped`.
+ *        Nodes (groups of tests) that contain tests with either of the specified results will be expanded.
+ * @param {boolean} [options.verbose] Show all tests, not just failed ones.
+ * @example makeCollapsible(root, { expand: "fail skipped", verbose: true });
+ */
 function makeCollapsible (node, options = {}) {
 	if (node.tests?.length) {
 		let expand = [...new Set((options.expand ?? "fail").split(/\s+/))];
 
+		// Root is collapsed by default.
 		// All groups are collapsed by default or if the verbose option is specified.
 		// Otherwise, it will be expanded if a group contains tests, because of which
 		// the group should be expanded (e.g., failed tests).

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -57,7 +57,7 @@ function getTree (msg, i) {
 
 // Render the tests stats
 function render (root, options) {
-	let messages = root.toString({ format: options.format ?? "rich" });
+	let messages = root.toString({ ...options, format: options.format ?? "rich" });
 	let tree = getTree(messages).toString();
 	tree = format(tree);
 

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -15,17 +15,17 @@ import { getType, interceptConsole, restoreConsole } from '../util.js';
 // Recursively traverse a subtree starting from `node` and make (only) groups of tests collapsible.
 // Consider the `expand` option, which specifies which groups should be expanded by default.
 // For example, `expand = "fail skipped"` will expand groups that contain failed or skipped tests.
-function makeCollapsible (node, o) {
+function makeCollapsible (node, { expand = "fail", verbose } = {}) {
 	if (node.tests?.length) {
-		let expand = [...new Set((o?.expand ?? "").split(/\s+/))];
+		let options = [...new Set((expand).split(/\s+/))];
 
 		// All groups are collapsed by default or if the verbose option is specified.
 		// Otherwise, it will be expanded if a group contains tests, because of which
 		// the group should be expanded (e.g., failed tests).
-		node.collapsed = !o?.verbose && expand.some(o => node.stats[o] > 0) ? false : true;
+		node.collapsed = node.parent && !verbose && options.some(o => node.stats[o] > 0) ? false : true;
 
 		for (let test of node.tests) {
-			makeCollapsible(test, o);
+			makeCollapsible(test, { expand, verbose });
 		}
 	}
 }
@@ -147,7 +147,6 @@ Press <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
 			readline.emitKeypressEvents(process.stdin);
 			process.stdin.setRawMode(true); // handle keypress events instead of Node
 
-			makeCollapsible(root, {...options, expand: options?.expand ?? "fail"});
 			root.highlighted = true;
 			render(root, options);
 

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -41,11 +41,12 @@ function getTree (msg, i) {
 	if (msg.collapsed !== undefined) {
 		let {collapsed, highlighted, children} = msg;
 
-		let icon = msg.collapsed ? "▶︎ " : "▼ ";
-		msg = icon + msg;
+		let icon = collapsed ? "▷" : "▽";
 		if (highlighted) {
+			icon = `<c green><b>${ collapsed ? "▶︎" : "▼" }</b></c>`;
 			msg = `<b>${ msg }</b>`;
 		}
+		msg = icon + " " + msg;
 		msg = new String(msg);
 		msg.collapsed = collapsed;
 		msg.children = collapsed ? [] : children;


### PR DESCRIPTION
This PR addressed issues discussed in #7:

- In verbose mode, don't skip child tests that have finished and everything passes
- Make the highlighted nodes more prominent
- Add support for the `expand` option—groups with failed child tests will be expanded by default
