### PR TITLE
[Interactive CLI] `render` should consider all passed options, not only `format`

### DIFF
--- a/src/env/node.js
+++ b/src/env/node.js
@@ -55,7 +55,7 @@ function getTree (msg, i) {
 }
 
 // Render the tests stats
-function render (root, options) {
+function render (root, options = {}) {
 	let messages = root.toString({ ...options, format: options.format ?? "rich" });
 	let tree = getTree(messages).toString();
 	tree = format(tree);

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -56,7 +56,7 @@ function getTree (msg, i) {
 
 // Render the tests stats
 function render (root, options) {
-	let messages = root.toString({ format: options.format ?? "rich" });
+	let messages = root.toString({ ...options, format: options.format ?? "rich" });
 	let tree = getTree(messages).toString();
 	tree = format(tree);
 


### PR DESCRIPTION
If it doesn't, passed tests will never be rendered, even in the `verbose` mode.

This is a cherry-pick from #31.