### PR TITLE
First stab at handling console messages while a test runs

### DIFF
--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -307,13 +307,14 @@ ${ this.error.stack }`);
 		let ret = [
 			`<b><bg ${color}><c white> ${ this.pass? "PASS" : "FAIL" } </c></bg></b>`,
 			`<c light${color}>${this.name ?? "(Anonymous)"}</c>`,
-			`<dim>(${ formatDuration(this.timeTaken ?? 0) })</dim>`,
 		].join(" ");
 
 		if (this.messages?.length > 0) {
 			let suffix = pluralize(this.messages.length, "message", "messages");
-			ret += ` <dim>(<b>${ this.messages.length }</b> console ${ suffix })</dim>`;
+			ret += ` <dim><b>${ this.messages.length }</b> console ${ suffix }</dim>`;
 		}
+
+		ret += ` <dim>(${ formatDuration(this.timeTaken ?? 0) })</dim>`;
 
 		if (this.details?.length > 0) {
 			ret += ": " + this.details.join(", ");

--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -401,8 +401,7 @@ ${ this.error.stack }`);
 			}
 
 			if (this.messages?.length > 0) {
-				ret.children ??= [];
-				ret.children.push(this.getMessages(o));
+				(ret.children ??= []).push(this.getMessages(o));
 			}
 
 			if (ret.children?.length > 0 || ret.messages?.length > 0) {

--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -311,7 +311,7 @@ ${ this.error.stack }`);
 
 		if (this.messages?.length > 0) {
 			let suffix = pluralize(this.messages.length, "message", "messages");
-			ret += ` <dim><b>${ this.messages.length }</b> console ${ suffix }</dim>`;
+			ret += ` <dim><b>${ this.messages.length }</b> ${ suffix }</dim>`;
 		}
 
 		ret += ` <dim>(${ formatDuration(this.timeTaken ?? 0) })</dim>`;
@@ -353,7 +353,7 @@ ${ this.error.stack }`);
 
 		if (stats.messages > 0) {
 			let suffix = pluralize(stats.messages, "message", "messages");
-			ret.push(`<dim><b>${ stats.messages }</b> console ${suffix}</dim>`);
+			ret.push(`<dim><b>${ stats.messages }</b> ${suffix}</dim>`);
 		}
 
 		let icon = stats.fail > 0? "❌" : stats.pending > 0? "⏳" : "✅";
@@ -375,7 +375,7 @@ ${ this.error.stack }`);
 	 * @returns {string}
 	 */
 	getMessages (o = {}) {
-		let ret = new String("<c yellow><b><i>(Console Messages)</i></b></c>");
+		let ret = new String("<c yellow><b><i>(Messages)</i></b></c>");
 		ret.children = this.messages.map(m =>`<dim>(${ m.method })</dim> ${m.args.join(" ")}`);
 
 		return o?.format === "rich" ? ret : stripFormatting(ret);

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -17,7 +17,7 @@ import { getType } from '../util.js';
  */
 function makeCollapsible (node) {
 	if (node.tests?.length || node.messages?.length) {
-		node.collapsed = true; // all groups and test with console messages are collapsed by default
+		node.collapsed = true; // all groups and console messages are collapsed by default
 
 		let nodes = [...(node.tests ?? []), ...(node.messages ?? [])];
 		for (let node of nodes) {

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -10,20 +10,25 @@ import { globSync } from 'glob';
 
 // Internal modules
 import format from "../format-console.js";
-import { getType, interceptConsole, restoreConsole } from '../util.js';
+import { getType } from '../util.js';
 
-// Recursively traverse a subtree starting from `node` and make (only) groups of tests collapsible
+/**
+ * Recursively traverse a subtree starting from `node` and make groups of tests and test with console messages collapsible.
+ */
 function makeCollapsible (node) {
-	if (node.tests?.length) {
-		node.collapsed = true; // all groups are collapsed by default
+	if (node.tests?.length || node.messages?.length) {
+		node.collapsed = true; // all groups and test with console messages are collapsed by default
 
-		for (let test of node.tests) {
-			makeCollapsible(test);
+		let nodes = [...(node.tests ?? []), ...(node.messages ?? [])];
+		for (let node of nodes) {
+			makeCollapsible(node);
 		}
 	}
 }
 
-// Recursively traverse a subtree starting from `node` and return all visible groups of tests
+/**
+ * Recursively traverse a subtree starting from `node` and return all visible groups of tests or tests with console messages.
+ */
 function getVisibleGroups (node, options, groups = []) {
 	groups.push(node);
 
@@ -119,23 +124,13 @@ export default {
 	},
 	setup () {
 		process.env.NODE_ENV = "test";
-		interceptedConsole = interceptConsole();
 	},
 	done (result, options, event, root) {
-		makeCollapsible(root)
+		makeCollapsible(root);
 		render(root, options);
 
 		if (root.stats.pending === 0) {
 			logUpdate.clear();
-
-			let {messages, originalConsole} = interceptedConsole;
-			restoreConsole(originalConsole);
-
-			// Replay all the suppressed messages from the tests
-			for (let message of messages) {
-				let {args, method} = message;
-				console[method](...args);
-			}
 
 			let hint = `
 Use <b>↑</b> and <b>↓</b> arrow keys to navigate groups of tests, <b>→</b> and <b>←</b> to expand and collapse them respectively.

--- a/src/util.js
+++ b/src/util.js
@@ -183,26 +183,38 @@ export function subsetTests (test, path) {
 	return tests;
 }
 
-export function interceptConsole () {
+/**
+ * Intercept console output while running a function.
+ * @param {Function} fn Function to run.
+ * @returns {Array<{args: Array<string>, method: string}>} Array of intercepted messages containing the used console method and passed arguments.
+ */
+export function interceptConsole (fn) {
+	const methods = ["log", "warn", "error"];
+
+	let originalConsole = {};
 	let messages = [];
 
-	function getOriginalConsole () {
-		const methods = ["log", "warn", "error", "info"];
-		let originalConsole = {};
-
-		for (let method of methods) {
-			originalConsole[method] = console[method];
-			console[method] = (...args) => messages.push({args, method});
-		}
-
-		return originalConsole;
+	for (let method of methods) {
+		originalConsole[method] = console[method];
+		console[method] = (...args) => messages.push({args, method});
 	}
 
-	return {messages, originalConsole: getOriginalConsole()};
-}
+	fn();
 
-export function restoreConsole (originalConsole) {
 	for (let method in originalConsole) {
 		console[method] = originalConsole[method];
 	}
+
+	return messages;
+}
+
+/**
+ * Pluralize a word.
+ * @param {number} n Number to check.
+ * @param {string} singular Singular form of the word.
+ * @param {string} plural Plural form of the word.
+ * @returns {string}
+ */
+export function pluralize (n, singular, plural) {
+	return n === 1 ? singular : plural;
 }


### PR DESCRIPTION
In this PR, I tried to implement [@LeaVerou's suggestion on handling console messages from tests](https://github.com/LeaVerou/htest/issues/7#issuecomment-2141051134), including (as an addition to the main algorithm):

- Refactor `interceptConsole()` so that it accepts a function as an argument
- Add utility `pluralize()` method to correctly print out “message”/“messages” to the console

Here is what we have as a starting point:


https://github.com/LeaVerou/htest/assets/9166277/61478182-77c6-4832-a0f8-8924d09deef9

Let's improve it and make it more awesome together!