### PR TITLE
Keyboard shortcuts

### DIFF
--- a/src/env/node.js
+++ b/src/env/node.js
@@ -175,9 +175,22 @@ Press <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
 					active.highlighted = true;
 					render(root, options);
 				}
-				else if (name === "left" && active.collapsed === false) {
-					active.collapsed = true;
-					render(root, options);
+				else if (name === "left") {
+					if (active.collapsed === false) {
+						active.collapsed = true;
+						render(root, options);
+					}
+					else if (active.parent) {
+						// If the current group is collapsed, collapse its parent group
+						let groups = getVisibleGroups(root, options);
+						let index = groups.indexOf(active.parent);
+						active = groups[index];
+						active.collapsed = true;
+
+						groups = groups.map(group => group.highlighted = false);
+						active.highlighted = true;
+						render(root, options);
+					}
 				}
 				else if (name === "right" && active.collapsed === true) {
 					active.collapsed = false;

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -151,10 +151,11 @@ export default {
 			logUpdate.clear();
 
 			let hint = `
-Use <b>↑</b> and <b>↓</b> arrow keys to navigate groups of tests, <b>→</b> and <b>←</b> to expand and collapse them respectively.
-Use <b>Ctrl+↑</b> and <b>Ctrl+↓</b> to go to the first or last child group of the current group, respectively.
-Press <b>Ctrl+Shift+←</b> to collapse all groups.
-Press <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
+Use <b>↑</b> and <b>↓</b> arrow keys to navigate groups of tests, <b>→</b> and <b>←</b> to expand and collapse them, respectively.
+Use <b>Ctrl+↑</b> and <b>Ctrl+↓</b> to go to the first or last child group of the current group.
+To expand or collapse the current group and all its subgroups, use <b>Ctrl+→</b> and <b>Ctrl+←</b>.
+Press <b>Ctrl+Shift+←</b> to collapse all groups, regardless of the current group.
+Use <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
 `;
 			hint = format(hint);
 			console.log(hint);

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -27,6 +27,24 @@ function makeCollapsible (node) {
 }
 
 /**
+ * Recursively traverse a subtree starting from `node`
+ * and make groups of tests and test with console messages
+ * either collapsed or expanded by setting its `collapsed` property.
+ * @param {object} node - The root node of the subtree.
+ * @param {boolean} collapsed - Whether to collapse or expand the subtree.
+ */
+function setCollapsed (node, collapsed = true) {
+	if (node.tests?.length || node.messages?.length) {
+		node.collapsed = collapsed;
+
+		let nodes = [...(node.tests ?? []), ...(node.messages ?? [])];
+		for (let node of nodes) {
+			setCollapsed(node, collapsed);
+		}
+	}
+}
+
+/**
  * Recursively traverse a subtree starting from `node` and return all visible groups of tests or tests with console messages.
  */
 function getVisibleGroups (node, options, groups = []) {
@@ -211,6 +229,11 @@ Press <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
 						active.highlighted = true;
 						render(root, options);
 					}
+					else if (key.ctrl) {
+						// Collapse the current group and all its subgroups on Ctrl+←
+						setCollapsed(active);
+						render(root, options);
+					}
 					else if (active.collapsed === false) {
 						active.collapsed = true;
 						render(root, options);
@@ -227,9 +250,16 @@ Press <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
 						render(root, options);
 					}
 				}
-				else if (name === "right" && active.collapsed === true) {
-					active.collapsed = false;
-					render(root, options);
+				else if (name === "right") {
+					if (key.ctrl) {
+						// Expand the current group and all its subgroups on Ctrl+→
+						setCollapsed(active, false);
+						render(root, options);
+					}
+					else if (active.collapsed === true) {
+						active.collapsed = false;
+						render(root, options);
+					}
 				}
 			});
 		}

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -134,6 +134,7 @@ export default {
 
 			let hint = `
 Use <b>↑</b> and <b>↓</b> arrow keys to navigate groups of tests, <b>→</b> and <b>←</b> to expand and collapse them respectively.
+Press <b>Ctrl+Shift+←</b> to collapse all groups.
 Press <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
 `;
 			hint = format(hint);
@@ -176,7 +177,18 @@ Press <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
 					render(root, options);
 				}
 				else if (name === "left") {
-					if (active.collapsed === false) {
+					if (key.ctrl && key.shift) {
+						// Collapse all groups on Ctrl+Shift+←
+						let groups = getVisibleGroups(root, options);
+						for (let group of groups) {
+							group.collapsed = true;
+							group.highlighted = false;
+						}
+						active = root;
+						active.highlighted = true;
+						render(root, options);
+					}
+					else if (active.collapsed === false) {
 						active.collapsed = true;
 						render(root, options);
 					}

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -209,9 +209,10 @@ Use <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
 						// Collapse all groups on Ctrl+Shift+←
 						let groups = getVisibleGroups(root, options);
 						for (let group of groups) {
-							group.collapsed = true;
 							group.highlighted = false;
 						}
+
+						setCollapsed(root);
 						active = root;
 						active.highlighted = true;
 						render(root, options);

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -13,20 +13,6 @@ import format from "../format-console.js";
 import { getType } from '../util.js';
 
 /**
- * Recursively traverse a subtree starting from `node` and make groups of tests and test with console messages collapsible.
- */
-function makeCollapsible (node) {
-	if (node.tests?.length || node.messages?.length) {
-		node.collapsed = true; // all groups and console messages are collapsed by default
-
-		let nodes = [...(node.tests ?? []), ...(node.messages ?? [])];
-		for (let node of nodes) {
-			makeCollapsible(node);
-		}
-	}
-}
-
-/**
  * Recursively traverse a subtree starting from `node`
  * and make groups of tests and test with console messages
  * either collapsed or expanded by setting its `collapsed` property.
@@ -144,7 +130,7 @@ export default {
 		process.env.NODE_ENV = "test";
 	},
 	done (result, options, event, root) {
-		makeCollapsible(root);
+		setCollapsed(root); // all groups and console messages are collapsed by default
 		render(root, options);
 
 		if (root.stats.pending === 0) {

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -134,6 +134,7 @@ export default {
 
 			let hint = `
 Use <b>↑</b> and <b>↓</b> arrow keys to navigate groups of tests, <b>→</b> and <b>←</b> to expand and collapse them respectively.
+Use <b>Ctrl+↑</b> and <b>Ctrl+↓</b> to go to the first or last child group of the current group, respectively.
 Press <b>Ctrl+Shift+←</b> to collapse all groups.
 Press <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
 `;
@@ -158,21 +159,43 @@ Press <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
 				else if (name === "up") {
 					// Figure out what group of tests is active (and should be highlighted)
 					let groups = getVisibleGroups(root, options);
-					let index = groups.indexOf(active);
-					index = Math.max(0, index - 1); // choose the previous group, but don't go higher than the root
-					active = groups[index];
 
-					groups = groups.map(group => group.highlighted = false);
+					if (key.ctrl) {
+						let parent = active.parent;
+						if (parent) {
+							active = groups.filter(group => group.parent === parent)[0]; // the first one from all groups with the same parent
+						}
+					}
+					else {
+						let index = groups.indexOf(active);
+						index = Math.max(0, index - 1); // choose the previous group, but don't go higher than the root
+						active = groups[index];
+					}
+
+					for (let group of groups) {
+						group.highlighted = false;
+					}
 					active.highlighted = true;
 					render(root, options);
 				}
 				else if (name === "down") {
 					let groups = getVisibleGroups(root, options);
-					let index = groups.indexOf(active);
-					index = Math.min(groups.length - 1, index + 1); // choose the next group, but don't go lower than the last one
-					active = groups[index];
 
-					groups = groups.map(group => group.highlighted = false);
+					if (key.ctrl) {
+						let parent = active.parent;
+						if (parent) {
+							active = groups.filter(group => group.parent === parent).at(-1); // the last one from all groups with the same parent
+						}
+					}
+					else {
+						let index = groups.indexOf(active);
+						index = Math.min(groups.length - 1, index + 1); // choose the next group, but don't go lower than the last one
+						active = groups[index];
+					}
+
+					for (let group of groups) {
+						group.highlighted = false;
+					}
 					active.highlighted = true;
 					render(root, options);
 				}

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -140,7 +140,7 @@ export default {
 Use <b>↑</b> and <b>↓</b> arrow keys to navigate groups of tests, <b>→</b> and <b>←</b> to expand and collapse them, respectively.
 Use <b>Ctrl+↑</b> and <b>Ctrl+↓</b> to go to the first or last child group of the current group.
 To expand or collapse the current group and all its subgroups, use <b>Ctrl+→</b> and <b>Ctrl+←</b>.
-Press <b>Ctrl+Shift+←</b> to collapse all groups, regardless of the current group.
+Press <b>Ctrl+Shift+→</b> and <b>Ctrl+Shift+←</b> to expand or collapse all groups, regardless of the current group.
 Use <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
 `;
 			hint = format(hint);
@@ -238,7 +238,12 @@ Use <b>^C</b> (<b>Ctrl+C</b>) or <b>q</b> to quit interactive mode.
 					}
 				}
 				else if (name === "right") {
-					if (key.ctrl) {
+					if (key.ctrl && key.shift) {
+						// Expand all groups on Ctrl+Shift+→
+						setCollapsed(root, false);
+						render(root, options);
+					}
+					else if (key.ctrl) {
 						// Expand the current group and all its subgroups on Ctrl+→
 						setCollapsed(active, false);
 						render(root, options);


### PR DESCRIPTION
Closes #37.

In this PR, I switched from the `Alt` key to `Ctrl` by addressing Lea's feedback and based on my experiments (there are issues when detecting `Alt` since it's interpreted as a meta key; I thought that meta corresponds to `⌘` on Mac and `Ctrl` on Windows 🤷‍♂️).

Anyhow, here is the list of supported keyboard shortcuts:

- `↑` — “Go Level Up” (current behavior)
- `↓` — “Go Level Down” (current behavior)
- `→` — “Expand Node” (current behavior)
- `←` — “Collapse Node” (current behavior)
- `Ctrl+↑` — “Go to the First Child of a Group”
- `Ctrl+↓` — “Go to the Last Child of a Group”
- `Ctrl+→` — “Expand Subtree” (starting from the current node) — the same as “Expand All” when performed on root
- `Ctrl+←` — “Collapse Subtree” (starting from the current node) — the same as “Collapse All” when performed on root
- `Ctrl+Shift+→` — “Expand All”
- `Ctrl+Shift+←` — “Collapse All”
- Consequent presses of `←` collapse the current node, then—the parent node, then—the grandparent node, and so on.