### PR TITLE
[node.js] Support running tests in Node in all OSs

### DIFF
--- a/src/env/node.js
+++ b/src/env/node.js
@@ -1,6 +1,7 @@
 // Native Node packages
 import fs from "fs";
 import path from "path";
+import { pathToFileURL } from "url";
 import * as readline from "node:readline";
 
 // Dependencies
@@ -91,7 +92,7 @@ async function getTestsIn (dir) {
 	let cwd = process.cwd();
 	let paths = filenames.map(name => path.join(cwd, dir, name));
 
-	return Promise.all(paths.map(path => import(path).then(module => module.default, err => {
+	return Promise.all(paths.map(path => import(pathToFileURL(path)).then(module => module.default, err => {
 		console.error(`Error importing tests from ${path}:`, err);
 	})));
 }
@@ -116,7 +117,7 @@ export default {
 				paths = getType(paths) === "string" ? [paths] : paths;
 				return paths.map(p => {
 					p = path.join(process.cwd(), p);
-					return import(p).then(m => m.default ?? m);
+					return import(pathToFileURL(p)).then(m => m.default ?? m);
 				});
 			});
 


### PR DESCRIPTION
Fixes the issue with `ERR_UNSUPPORTED_ESM_URL_SCHEME` on Windows ([reported](https://github.com/color-js/color.js/pull/616#issue-2747672182) in the Color.js repo). Now, `hTest` should work in all major OSs.

We still have some UI glitches because our emojis are not well-supported in different Windows terminals. But I think we can work on it in a different PR.

<img width="917" alt="image" src="https://github.com/user-attachments/assets/949966e8-f398-4be9-8ff1-a0dfca1b2d67" />

<img width="976" alt="image" src="https://github.com/user-attachments/assets/454acbf3-66d5-4609-8b15-7cba15f06f26" />
