### PR TITLE
[TestResult] Add missed import

### DIFF
--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -1,3 +1,4 @@
+import Test from "./Test.js";
 import BubblingEventTarget from "./BubblingEventTarget.js";
 import format, { stripFormatting } from "../format-console.js";
 import { delay, formatDuration, interceptConsole, pluralize, stringify, formatDiff } from "../util.js";


### PR DESCRIPTION
On line 80, we reference the `Test` class to access its `warn()` method. I wonder how it hasn’t bitten us yet. 🤔