### PR TITLE
Always show summary output in CI mode when all tests pass

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -352,7 +352,8 @@ tests: rawCases.map(c => ({ ...c, expect: referenceImpl(c.arg) })),
 npx htest test/file.js       # Single file
 npx htest test/               # All JS in directory (not recursive, skips index*)
 npx htest test/index.js       # Use index files for recursive aggregation
-npx htest test/file.js --ci   # CI mode: exits with code 1 on failure
+npx htest test/file.js --ci       # Force non-interactive mode (automatic in non-TTY environments)
+npx htest test/file.js --verbose  # Show all tests, including passing
 ```
 
 ---

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -135,13 +135,11 @@ export default {
 
 		if (!isInteractive) {
 			if (root.stats.pending === 0) {
-				if (root.stats.fail > 0 || options.verbose) {
-					let messages = root.toString(options);
-					let tree = getTree(messages).toString();
-					tree = format(tree);
+				let messages = root.toString(options);
+				let tree = getTree(messages).toString();
+				tree = format(tree);
 
-					console[root.stats.fail > 0 ? "error" : "log"](tree);
-				}
+				console[root.stats.fail > 0 ? "error" : "log"](tree);
 
 				process.exit(root.stats.fail > 0 ? 1 : 0);
 			}


### PR DESCRIPTION
Previously, non-interactive mode produced no output when all tests passed (only failures or `—verbose` triggered output). Every major JS testing framework always prints at least a summary — align with that convention.

Also document `—verbose` flag in `SKILL.md` so AI agents know it exists.