### PR TITLE
Refine SKILL.md: principles, structure, examples

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -37,7 +37,7 @@ export default {
 
 - **What abstraction makes the tests easier to understand for humans?** If a rule below would impose an abstraction that makes a test harder to read, the rule is wrong for that test. Declarativeness exists to remove repetitive noise — not to force inherently imperative code into a data shape.
 
-- **Write the tests first; scaffold around them.** Express each test as data (`name`, `arg`, `expect`) in whatever shape gives you maximum signal-to-noise on the intent. Write `run()`, `beforeEach()`, and other scaffolding *at the end*, derived from what the tests need. Starting with `run()` first shapes the tests around what `run()` can express, instead of letting the tests express the intent.
+- **Write the tests first; scaffold around them.** Express each test as data (`name`, `arg`, `expect`) in whatever shape gives you maximum signal-to-noise on the intent. **DRY isn't the endgame — it often correlates with clarity, but not always.** Write `run()`, `beforeEach()`, and other scaffolding *at the end*, derived from what the tests need. **When deciding whether to factor `run()` out or leave it per-test, write the test both ways and pick the version that expresses intent better.**
 
 1. **`arg` + `expect` is the default *for value transforms*.** When a test naturally fits "given input, expect output," express it that way. **Don't bend stateful or imperative tests into this shape.** Lifting `run` to a shared level pays off only when the abstraction *simplifies*. If it would require encoding sequential side effects as `arg` data — an array of functions whose job is to mutate state — leave `run` per-test: the imperative content stays where the reader expects it. When several tests genuinely share execution, group *those* under a focused `run` rather than forcing the whole file under one root-level shape.
 2. **Structure mirrors API** — nest test groups to match your module's shape. One export = one top-level group. The hierarchy should let you locate any test by navigating the API.
@@ -49,12 +49,12 @@ export default {
 
 | Mistake                                               | Fix                                                                                          |
 | ----------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Custom `run` in every test with identical bodies      | Extract shared `run` at parent. **But** if each test's `run` has unique imperative content (writes, sequences), per-test is correct — don't impose uniformity. |
+| Custom `run` in every test with minor differences     | Extract shared `run` at parent and push the variations into `arg`/`args`. **But** if each test's `run` has unique imperative content (writes, sequences), per-test is correct — don't impose uniformity. |
 | `expect: true` with boolean logic in `run`            | Usually a smell — return the actual value. **Exception:** when the test name is a yes/no question or assertion (e.g. "Inputs are sorted", "Cache hit on repeat read"), the boolean is the literal answer to the name and `expect: true` is fine. |
 | Reading values via `this.arg.X` / `this.args[0]` inside `run` | The parameter list IS where `arg`/`args` arrive. Name and unpack them however fits the case: `run ({ x })`, `run ([first, ...rest])`, `run (args) { let first = args[0]; }`, etc. Reserve `this` for `this.data` (lifecycle state) and instance props. |
 | Inline `//` comment explaining what the test verifies | Use the `description` field — that's its home as structured metadata next to the test. **Keep it brief** (a sentence, maybe two): add what the `name` can't carry — an issue reference, a subtle invariant, a non-obvious edge case. Don't write a paragraph and don't restate the name in prose. Reserve comments for short notes about mechanics. |
 | Setup in `beforeAll` but used in `arg` expressions    | Move to module top level — `arg`/`expect` evaluate at import time, before hooks              |
-| `new Instance()` in both `arg` and `expect`           | Share one instance variable                                                                  |
+| `new Instance()` in both `arg` and `expect`           | Share one instance variable — default check uses `===` at leaves, so two structurally-equal instances fail. See [Reference Equality for Instances](#reference-equality-for-instances). |
 | `data` for values only used in `run`                  | Inline the value directly                                                                    |
 | `args: [1, 2, 3]` when function expects one array     | Use `arg: [1, 2, 3]` — `args` spreads elements as separate arguments                         |
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,9 +7,11 @@ description: Use when writing or modifying tests with hTest (htest.dev) — JS-f
 
 Two modes: **JS-first** for logic (runs in Node or browser, CI-compatible) and **HTML-first** for UI (runs in browser only, reactive).
 
+Full reference: <https://htest.dev>. This skill summarizes common patterns and pitfalls — when in doubt about a property's exact semantics, the docs are the source of truth.
+
 ## JS-First Mode
 
-Declarative testing framework. Tests are nested object literals — most tests need only `arg` + `expect`.
+Tests are nested object literals; properties cascade from parent to child, so you only specify what differs.
 
 ## Core Pattern
 
@@ -29,6 +31,33 @@ export default {
 };
 ```
 
+## Best Practices
+
+**Two principles guide everything below.** Come back to these whenever a specific rule seems wrong for your test:
+
+- **What abstraction makes the tests easier to understand for humans?** If a rule below would impose an abstraction that makes a test harder to read, the rule is wrong for that test. Declarativeness exists to remove repetitive noise — not to force inherently imperative code into a data shape.
+
+- **Write the tests first; scaffold around them.** Express each test as data (`name`, `arg`, `expect`) in whatever shape gives you maximum signal-to-noise on the intent. Write `run()`, `beforeEach()`, and other scaffolding *at the end*, derived from what the tests need. Starting with `run()` first shapes the tests around what `run()` can express, instead of letting the tests express the intent.
+
+1. **`arg` + `expect` is the default *for value transforms*.** When a test naturally fits "given input, expect output," express it that way. **Don't bend stateful or imperative tests into this shape.** Lifting `run` to a shared level pays off only when the abstraction *simplifies*. If it would require encoding sequential side effects as `arg` data — an array of functions whose job is to mutate state — leave `run` per-test: the imperative content stays where the reader expects it. When several tests genuinely share execution, group *those* under a focused `run` rather than forcing the whole file under one root-level shape.
+2. **Structure mirrors API** — nest test groups to match your module's shape. One export = one top-level group. The hierarchy should let you locate any test by navigating the API.
+3. **Check the shape, not every byte** — use `check: { subset: true }` when you only care about specific properties. Tests that over-specify `expect` break for wrong reasons.
+4. **Each test = one unique branch** — don't test the same code path twice with different data. A passing duplicate isn't a safety net.
+5. **Don't test the language** — spread, object merge, array methods: those are JavaScript, not your code. Only test behavior your function owns.
+
+## Common Mistakes
+
+| Mistake                                               | Fix                                                                                          |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Custom `run` in every test with identical bodies      | Extract shared `run` at parent. **But** if each test's `run` has unique imperative content (writes, sequences), per-test is correct — don't impose uniformity. |
+| `expect: true` with boolean logic in `run`            | Usually a smell — return the actual value. **Exception:** when the test name is a yes/no question or assertion (e.g. "Inputs are sorted", "Cache hit on repeat read"), the boolean is the literal answer to the name and `expect: true` is fine. |
+| Reading values via `this.arg.X` / `this.args[0]` inside `run` | The parameter list IS where `arg`/`args` arrive. Name and unpack them however fits the case: `run ({ x })`, `run ([first, ...rest])`, `run (args) { let first = args[0]; }`, etc. Reserve `this` for `this.data` (lifecycle state) and instance props. |
+| Inline `//` comment explaining what the test verifies | Use the `description` field — that's its home as structured metadata next to the test. **Keep it brief** (a sentence, maybe two): add what the `name` can't carry — an issue reference, a subtle invariant, a non-obvious edge case. Don't write a paragraph and don't restate the name in prose. Reserve comments for short notes about mechanics. |
+| Setup in `beforeAll` but used in `arg` expressions    | Move to module top level — `arg`/`expect` evaluate at import time, before hooks              |
+| `new Instance()` in both `arg` and `expect`           | Share one instance variable                                                                  |
+| `data` for values only used in `run`                  | Inline the value directly                                                                    |
+| `args: [1, 2, 3]` when function expects one array     | Use `arg: [1, 2, 3]` — `args` spreads elements as separate arguments                         |
+
 ## Test Object Properties
 
 All properties are optional and inherit from parent to child.
@@ -39,7 +68,7 @@ All properties are optional and inherit from parent to child.
 | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `run`       | Function to execute. Called via `run.apply(testInstance, args)`. Inherited from parent — define once, never repeat. If omitted, result defaults to `args[0]`                                                          |
 | `arg`       | Single argument passed to `run`. Can be any value                                                                                                                                                                     |
-| `args`      | Array of arguments passed to `run`. Non-arrays auto-wrapped. `arg` takes precedence. **If your function takes an array as a single argument, use `arg` — `args: [1, 2, 3]` calls `fn(1, 2, 3)`, not `fn([1, 2, 3])`** |
+| `args`      | Array of arguments passed to `run`. Non-arrays auto-wrapped. `arg` takes precedence                                                                                                                                  |
 | `expect`    | Expected result. Deep equality by default                                                                                                                                                                             |
 | `getExpect` | Function to generate expected value dynamically. Called like `run`: `getExpect.apply(test, args)`. Inherited. `expect` takes precedence if both are set                                                               |
 | `throws`    | `true` (any error), `false` (asserts no error thrown), Error subclass (`TypeError`), or predicate `e => e.code === "ENOENT"`. Inherited                                                                               |
@@ -122,8 +151,8 @@ export default {
 
 | Property                   | Description                                                                                    |
 | -------------------------- | ---------------------------------------------------------------------------------------------- |
-| `beforeEach` / `afterEach` | Run before/after each test. Inherited. `afterEach` runs even if the test throws. Sync or async |
-| `beforeAll` / `afterAll`   | Run before/after all tests in the group where defined. **Not inherited**                       |
+| `beforeEach` / `afterEach` | Run before/after each test. Receive no parameters — access state via `this.data`, `this.arg`, etc. Inherited. `afterEach` runs even if the test throws. Sync or async |
+| `beforeAll` / `afterAll`   | Run before/after all tests in the group where defined. Receive no parameters — access state via `this.data`, `this.arg`. **Not inherited** |
 
 ## `this` Inside `run`
 
@@ -240,7 +269,7 @@ let config = new Map([["key", "value"]]);
 
 ## `data` — Shared Fixtures
 
-`data` shines when multiple tests operate on the same complex object or when nested groups need to vary a single configuration parameter while sharing everything else.
+`data` is a cascading object accessible to `run` and any setup hook via `this.data`. A test's `data` merges with its parent's, so common values can live at a higher level and be overridden where needed. The full definition lives in the docs ([define / data](https://htest.dev/define/#data)) — what follows is patterns that come up in practice.
 
 **Good use: shared object, accessed via `this.data`**
 
@@ -276,6 +305,37 @@ export default {
 			name: "loose mode",
 			data: { mode: "loose" },
 			tests: [{ arg: "foo", expect: "foo" }],
+		},
+	],
+};
+```
+
+**Good use: setup hook builds a per-test fixture for `run`**
+
+When setup is more involved than a literal value — instantiating a class, opening a connection, assembling a DOM tree — do it in `beforeEach` and stash the result on `this.data` so `run` (and `afterEach`) can use it. `beforeEach`/`afterEach` are invoked with no arguments, so they read `this.arg` and write `this.data`. `run` still receives its args via the parameter list.
+
+```js
+export default {
+	beforeEach () {
+		let parser = new Parser(this.arg.options);
+		Object.assign(this.data, { parser });
+	},
+	afterEach () {
+		this.data.parser.close();
+	},
+	run ({ input }) {
+		return this.data.parser.parse(input);
+	},
+	tests: [
+		{
+			name: "strict mode rejects extra whitespace",
+			arg: { options: { strict: true }, input: "1, 2, 3" },
+			throws: SyntaxError,
+		},
+		{
+			name: "loose mode parses anyway",
+			arg: { options: { strict: false }, input: "1, 2, 3" },
+			expect: [1, 2, 3],
 		},
 	],
 };
@@ -452,26 +512,3 @@ Automates clicks for reactive tests. Syntax: `[selector] [wait Ns] [after eventn
 | Real DOM / web components | —        | ✅         |
 | Simulated interactions    | —        | ✅         |
 | Reactive re-evaluation    | —        | ✅         |
-
----
-
-## Best Practices
-
-1. **`arg` + `expect` is the default** — any test that can't be expressed this way is a smell. If you're writing a custom `run` per test, pull a shared `run` up to the group level instead.
-2. **Structure mirrors API** — nest test groups to match your module's shape. One export = one top-level group. The hierarchy should let you locate any test by navigating the API.
-3. **Check the shape, not every byte** — use `check: { subset: true }` when you only care about specific properties. Tests that over-specify `expect` break for wrong reasons.
-4. **Each test = one unique branch** — don't test the same code path twice with different data. A passing duplicate isn't a safety net.
-5. **Don't test the language** — spread, object merge, array methods: those are JavaScript, not your code. Only test behavior your function owns.
-
-## Common Mistakes
-
-| Mistake                                               | Fix                                                                                          |
-| ----------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Custom `run` in every test                            | Extract shared `run` at parent, vary via `arg`                                               |
-| `expect: true` with boolean logic in `run`            | Return the actual result, use `map`/`check` for comparison                                   |
-| Setup in `beforeAll` but used in `arg` expressions    | Move to module top level — `arg`/`expect` evaluate at import time, before hooks              |
-| `new Instance()` in both `arg` and `expect`           | Share one instance variable                                                                  |
-| `data` for values only used in `run`                  | Inline the value directly                                                                    |
-| Testing spread/merge behavior                         | That's testing JavaScript, not your function                                                 |
-| `args: [1, 2, 3]` when function expects one array     | Use `arg: [1, 2, 3]` — `args` spreads elements as separate arguments                         |
-| `run (value)` or `run (input)` instead of `run (arg)` | Name the parameter `arg` — it mirrors the test property and signals the declarative contract |


### PR DESCRIPTION
## Summary

Iterates on `SKILL.md` from a real session using it to refactor a downstream project's tests. Three themes: frontload principles, cut duplications, capture gotchas.

## Key changes

- **Restructure:** Best Practices + Common Mistakes moved up to right after Core Pattern, so principles frame the mechanics that follow.
- **Two foundational principles** atop Best Practices, as meta-rules that override specific guidance below on conflict:
  - *What abstraction makes the tests easier to understand for humans?*
  - *Write the tests first; scaffold around them.*
- **New Common Mistakes rows:** reading values via `this.arg.X` inside `run` (use the parameter list); `//` comments for test intent (use `description`, kept brief).
- **Tightened rows:** `expect: true` (smell, with yes/no-question-name exception); custom `run` per test (identical bodies vs unique imperative content).
- **New `data` example:** setup hook stashing a per-test fixture for `run`, with the hook-vs-`run` parameter-access asymmetry called out.
- **Docs reference:** top-of-file pointer to <https://htest.dev> + specific link to [`data` docs](https://htest.dev/define/#data).
- **Removed duplications:** `args` vs `arg` warning, "don't test the language", over-prescriptive `run (value)` row.

Preview: https://deploy-preview-130--h-test.netlify.app/skill.html