### PR TITLE
CSS console output for browsers; clean ANSI in non-TTY

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@11ty/eleventy": "^3.1.5",
         "@11ty/eleventy-navigation": "^1.0.5",
         "@stylistic/eslint-plugin": "latest",
-        "chalk": "^5.6.2",
         "eleventy-plugin-toc": "^1.1.5",
         "eslint": "latest",
         "globals": "latest",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@11ty/eleventy": "^3.1.5",
     "@11ty/eleventy-navigation": "^1.0.5",
     "@stylistic/eslint-plugin": "latest",
-    "chalk": "^5.6.2",
     "eleventy-plugin-toc": "^1.1.5",
     "eslint": "latest",
     "globals": "latest",

--- a/src/env/console.js
+++ b/src/env/console.js
@@ -2,14 +2,14 @@ import format from "../format-console.js";
 
 function printTree (str, parent) {
 	if (str.children?.length > 0) {
-		console["group" + (parent ? "Collapsed" : "")](format(str));
+		console["group" + (parent ? "Collapsed" : "")](...format(str));
 		for (let child of str.children) {
 			printTree(child, str);
 		}
 		console.groupEnd();
 	}
 	else {
-		console.log(format(str));
+		console.log(...format(str));
 	}
 }
 

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -10,7 +10,7 @@ import { AsciiTree } from "oo-ascii-tree";
 import { globSync } from "glob";
 
 // Internal modules
-import format from "../format-console.js";
+import format, { stripFormatting } from "../format-console.js";
 import { getType } from "../util.js";
 
 /**
@@ -137,7 +137,7 @@ export default {
 			if (root.stats.pending === 0) {
 				let messages = root.toString(options);
 				let tree = getTree(messages).toString();
-				tree = format(tree);
+				tree = process.stdout.isTTY ? format(tree) : stripFormatting(tree);
 
 				console[root.stats.fail > 0 ? "error" : "log"](tree);
 

--- a/src/format-console.js
+++ b/src/format-console.js
@@ -3,18 +3,22 @@
  */
 // https://stackoverflow.com/a/41407246/90826
 let modifiers = {
-	reset: "\x1b[0m",
-	b:     "\x1b[1m",
-	dim:   "\x1b[2m",
-	i:     "\x1b[3m",
+	reset: { ansi: "\x1b[0m", css: "" },
+	b:     { ansi: "\x1b[1m", css: "font-weight: bold" },
+	dim:   { ansi: "\x1b[2m", css: "opacity: 0.6" },
+	i:     { ansi: "\x1b[3m", css: "font-style: italic" },
 };
 
 let hues = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"];
 
-let colors = Object.fromEntries(hues.map((hue, i) => [hue, `\x1b[3${i}m`]));
-let bgColors = Object.fromEntries(hues.map((hue, i) => [hue, `\x1b[4${i}m`]));
+let cssLightOverrides = {
+	black: "gray",
+	red: "lightcoral",
+	magenta: "violet",
+	white: "whitesmoke",
+};
 
-function getColorCode (hue, {light, bg} = {}) {
+function getColor (hue, {light, bg, mode} = {}) {
 	if (!hue) {
 		return "";
 	}
@@ -28,11 +32,16 @@ function getColorCode (hue, {light, bg} = {}) {
 		return "";
 	}
 
+	if (mode === "css") {
+		let cssHue = light ? (cssLightOverrides[hue] ?? "light" + hue) : hue;
+		return `${ bg ? "background" : "color" }: ${ cssHue }`;
+	}
+
 	if (light) {
 		return `\x1b[${ bg ? 10 : 9 }${i}m`;
 	}
 
-	return `\x1b[${ light ? "1;" : ""}${ bg ? 4 : 3 }${i}m`;
+	return `\x1b[${ bg ? 4 : 3 }${i}m`;
 }
 
 let tags = [
@@ -42,9 +51,28 @@ let tags = [
 ];
 let tagRegex = RegExp(tags.flat().join("|"), "gi");
 
+function getCSS (active, colorStack, bgStack, mode) {
+	let parts = [];
+	for (let mod of active) {
+		parts.push(modifiers[mod].css);
+	}
+	let fg = getColor(colorStack.at(-1), {mode});
+	if (fg) {
+		parts.push(fg);
+	}
+	let bg = getColor(bgStack.at(-1), {bg: true, mode});
+	if (bg) {
+		parts.push(bg);
+	}
+	return parts.join("; ");
+}
+
 export default function format (str) {
+	// Not IS_NODEJS — must re-evaluate at call time so tests can patch process.versions
+	let mode = typeof process === "object" && process?.versions?.node ? "ansi" : "css";
+
 	if (!str) {
-		return str;
+		return mode === "ansi" ? str : [];
 	}
 
 	str = str + "";
@@ -52,7 +80,8 @@ export default function format (str) {
 	let active = new Set();
 	let colorStack = [];
 	let bgStack = [];
-	return str.replace(tagRegex, tag => {
+	let styles = [];
+	str = str.replace(tagRegex, tag => {
 		let isClosing = tag[1] === "/";
 		let name = tag.match(/<\/?(\w+)/)[1];
 		let color = tag.match(/<(?:bg|c)\s+(\w+)>/)?.[1];
@@ -72,27 +101,40 @@ export default function format (str) {
 				return "";
 			}
 
-			let activeColor = colorStack.at(-1);
-			let colorModifier = getColorCode(activeColor);
-			let activeBg = bgStack.at(-1);
-			let bgColorModifier = getColorCode(activeBg, {bg: true});
-			return modifiers.reset + [...active].map(name => modifiers[name]).join("") + colorModifier + bgColorModifier;
+			if (mode === "css") {
+				styles.push(getCSS(active, colorStack, bgStack, mode));
+				return "%c";
+			}
+
+			let activeColor = getColor(colorStack.at(-1), {mode});
+			let activeBg = getColor(bgStack.at(-1), {bg: true, mode});
+			return modifiers.reset.ansi + [...active].map(name => modifiers[name].ansi).join("") + activeColor + activeBg;
 		}
 		else {
 			if (name === "c") {
 				colorStack.push(color);
-				return getColorCode(color);
 			}
 			else if (name === "bg") {
 				bgStack.push(color);
-				return getColorCode(color, {bg: true});
 			}
 			else {
 				active.add(name);
-				return modifiers[name];
 			}
+
+			if (mode === "css") {
+				styles.push(getCSS(active, colorStack, bgStack, mode));
+				return "%c";
+			}
+
+			if (name === "c" || name === "bg") {
+				return getColor(color, {bg: name === "bg", mode});
+			}
+
+			return modifiers[name].ansi;
 		}
 	});
+
+	return mode === "css" ? [str, ...styles] : str;
 }
 
 export function stripFormatting (str) {

--- a/src/render.js
+++ b/src/render.js
@@ -83,7 +83,7 @@ export default function render (test) {
 			}
 			else if (!target.pass) {
 				cell.classList.add("details");
-				cell.onclick = () => console.log(target.details.map(format).join("\n"));
+				cell.onclick = () => console.log(...format(target.details.join("\n")));
 			}
 			tr.dataset.time = formatDuration(target.timeTaken);
 		}

--- a/tests/format-console.js
+++ b/tests/format-console.js
@@ -1,5 +1,4 @@
 import format, { stripFormatting } from "../src/format-console.js";
-import chalk from "chalk";
 
 // We don't want to use map because it will output unmapped values on fail as well, causing a mess in this very special case
 function escape (str) {
@@ -33,14 +32,37 @@ export default {
 				{
 					name: "Light color",
 					args: "<c lightred>light red</c>",
-					// expect: "\\x1b[91mlight red\\x1b[0m"
-					expect: escape(chalk.redBright("light red")),
+					expect: "\\x1b[91mlight red\\x1b[0m",
 				},
 				{
 					name: "Light background color",
 					args: "<bg lightred>light red</bg>",
-					// expect: "\\x1b[101mlight red\\x1b[0m"
-					expect: escape(chalk.bgRedBright("light red")),
+					expect: "\\x1b[101mlight red\\x1b[0m",
+				},
+			],
+		},
+		{
+			name: "CSS formatting",
+			run (str) {
+				let node = process.versions.node;
+				delete process.versions.node;
+				let ret = format(str);
+				process.versions.node = node;
+				return ret;
+			},
+			tests: [
+				{
+					name: "Nested modifiers + colors",
+					args: "<b><bg green><c white> PASS </c></bg></b>",
+					expect: [
+						"%c%c%c PASS %c%c%c",
+						"font-weight: bold",
+						"font-weight: bold; background: green",
+						"font-weight: bold; color: white; background: green",
+						"font-weight: bold; background: green",
+						"font-weight: bold",
+						"",
+					],
 				},
 			],
 		},

--- a/tests/format-console.js
+++ b/tests/format-console.js
@@ -10,6 +10,7 @@ export default {
 	tests: [
 		{
 			name: "Formatting",
+			skip: typeof process === "undefined",
 			run (str) {
 				return escape(format(str));
 			},
@@ -43,6 +44,7 @@ export default {
 		},
 		{
 			name: "CSS formatting",
+			skip: typeof process === "undefined",
 			run (str) {
 				let node = process.versions.node;
 				delete process.versions.node;


### PR DESCRIPTION
## Summary
- `format()` returns `[text, ...styles]` for `%c` CSS styling in browsers (colored output in Firefox/Safari/Chrome)
- Unified modifiers dict with `{ansi, css}` per modifier; shared `getColor()` for both modes
- Node non-interactive path strips ANSI when stdout is not a TTY; `--ci` in a terminal keeps colors
- Fix console formatting tests: use literal ANSI strings instead of chalk
- Remove chalk dependency

## Test plan
- [x] `npm test` — 50/56 pass (6 are intentional failure tests)
- [x] Piped output is clean (no ANSI escape codes)
- [x] Browser console outputs `%c` styled text (verified via Playwright)
- [x] `--ci` in a terminal still shows colored output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

The output in the console in Safari and Firefox is much, much better now (we can see real colors instead of ANSI codes). Of course there's room for improvement, but I'd leave it for a follow-up PR.

<img width="423" height="131" alt="image" src="https://github.com/user-attachments/assets/dfb14f42-2385-4d72-a45e-f2a4e0d45fbb" />

And when Claude runs tests, it also sees the clean output now (only the relevant info without any noise).