### PR TITLE
Fix this.parent resolution for inherited functions

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -162,7 +162,7 @@ export default {
 - `this.data` — inherited data object
 - `this.name` — test name
 - `this.level` — nesting depth (root = 0). Useful in `getName` for depth-aware labels
-- `this.parent` — parent test/group. Useful for extending the parent's `run` in a child: call `this.parent.run(...args)` first, then transform the result
+- `this.parent` — parent test/group. Useful for calling the parent's version of an inherited function (e.g., `this.parent.run(...args)`, `this.parent.beforeEach()`). Automatically resolves to the nearest ancestor with a different version, so it works at any nesting depth without `.call(this)` or chaining `.parent.parent`
 - `this.expect` — expected value
 
 ## Async

--- a/src/classes/Test.js
+++ b/src/classes/Test.js
@@ -5,6 +5,7 @@ import { stringify } from "../util.js";
  * Represents a single test or a group of tests
  */
 export default class Test {
+	#parent = null;
 	data = {};
 
 	constructor (test, parent) {
@@ -14,7 +15,7 @@ export default class Test {
 		}
 
 		if (parent) {
-			test.parent = parent;
+			this.#parent = parent;
 			this.level = parent.level + 1;
 		}
 		else {
@@ -23,7 +24,7 @@ export default class Test {
 
 		Object.assign(this, test);
 
-		this.data = Object.create(this.parent?.data ?? null, Object.getOwnPropertyDescriptors(this.data));
+		this.data = Object.create(this.#parent?.data ?? null, Object.getOwnPropertyDescriptors(this.data));
 		this.originalName = this.name;
 
 		if (typeof this.name === "function") {
@@ -32,10 +33,10 @@ export default class Test {
 
 		// Inherit properties from parent
 		// This works recursively because the parent constructor runs before its children
-		if (this.parent) {
+		if (this.#parent) {
 			for (let prop of ["beforeEach", "run", "afterEach", "map", "check", "getName", "args", "expect", "getExpect", "throws", "maxTime", "maxTimeAsync", "skip"]) {
-				if (!(prop in this) && prop in this.parent) {
-					this[prop] = this.parent[prop];
+				if (!(prop in this) && prop in this.#parent) {
+					this[prop] = this.#parent[prop];
 				}
 			}
 		}
@@ -85,6 +86,54 @@ export default class Test {
 				this.expect = this.args[0];
 			}
 		}
+	}
+
+	// Proxy so this.parent.foo() inside an inherited function resolves to
+	// the nearest ancestor with a different foo, not the same inherited one.
+	get parent () {
+		let self = this;
+		let target = this.#parent;
+
+		if (!target) {
+			return null;
+		}
+
+		return new Proxy(target, {
+			get (/** @type {Test} */ test, prop) {
+				let value = test[prop];
+
+				if (typeof prop === "symbol" || typeof value !== "function") {
+					return value;
+				}
+
+				if (self[prop] === value) {
+					/** @type {Test} */
+					let ancestor = test.#parent;
+
+					while (ancestor) {
+						let ancestorValue = ancestor[prop];
+
+						if (typeof ancestorValue === "function" && ancestorValue !== value) {
+							return function (...args) {
+								let originalParent = self.#parent;
+								self.#parent = ancestor.#parent;
+
+								try {
+									return ancestorValue.call(self, ...args);
+								}
+								finally {
+									self.#parent = originalParent;
+								}
+							};
+						}
+
+						ancestor = ancestor.#parent;
+					}
+				}
+
+				return value.bind(self);
+			},
+		});
 	}
 
 	get isTest () {

--- a/tests/parent.js
+++ b/tests/parent.js
@@ -1,0 +1,48 @@
+export default {
+	name: "this.parent",
+	run (x) {
+		return x * 2;
+	},
+	tests: [
+		{
+			name: "this.parent.foo() resolves to ancestor version when inherited",
+			tests: [
+				{
+					run (x) {
+						return this.parent.run(x) + 1;
+					},
+					tests: [{ arg: 3, expect: 7 }],
+				},
+			],
+		},
+		{
+			name: "this.parent.foo() skips levels that didn't redefine it",
+			beforeEach () {
+				this.data.calls = ["root"];
+			},
+			tests: [
+				{
+					name: "Level 1",
+					// No beforeEach; skip to the root level
+					tests: [
+						{
+							name: "Level 2",
+							tests: [
+								{
+									beforeEach () {
+										this.parent.beforeEach();
+										(this.data.calls ??= []).push(this.name);
+									},
+									run () {
+										return this.data.calls;
+									},
+									tests: [{ name: "Level 3", expect: ["root", "Level 3"] }],
+								},
+							],
+						},
+					],
+				},
+			],
+		},
+	],
+};


### PR DESCRIPTION
## Summary

- `this.parent.foo()` inside an inherited function now resolves to the nearest ancestor with a different version, not the same inherited one
- Eliminates `this.parent.parent` chaining and `.call(this)` for super-call patterns
- Uses a private `#parent` field with a Proxy getter

## Test plan

- [x] `npm test` — all existing tests pass, no regressions
- [x] `npx htest tests/parent.js --verbose` — new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)