### PR TITLE
Inherit data via prototype chain, closes #117

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ These cascade from parent to child (set in `Test.js` constructor):
 beforeEach  run  afterEach  map  check  getName  args  expect  getExpect  throws  maxTime  maxTimeAsync  skip
 ```
 
-NOT inherited: `beforeAll`, `afterAll`, `name`. `data` is merged (child extends parent), not replaced.
+NOT inherited: `beforeAll`, `afterAll`, `name`. `data` inherits via prototype chain (child sees parent's data; own properties shadow parent's).
 
 ## Self-hosted testing
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -81,7 +81,7 @@ All properties are optional and inherit from parent to child.
 | `getName`     | Function to generate names dynamically. Called like `run`: `getName.apply(test, args)`. Inherited (unlike `name`)                |
 | `description` | Human-readable explanation of the test's intent or edge case. Ignored by the runner                                              |
 | `tests`       | Array of child tests. If present, this is a group (parent); if absent, a leaf test                                               |
-| `data`        | Inherited object accessible via `this.data`. Child data merges with parent                                                       |
+| `data`        | Inherited object accessible via `this.data`. Child inherits parent's data via prototype chain; own properties shadow parent's     |
 | `skip`        | `true` or function returning truthy to skip. Inherited — setting on a parent skips all children                                  |
 
 ### Comparison
@@ -269,7 +269,7 @@ let config = new Map([["key", "value"]]);
 
 ## `data` — Shared Fixtures
 
-`data` is a cascading object accessible to `run` and any setup hook via `this.data`. A test's `data` merges with its parent's, so common values can live at a higher level and be overridden where needed. The full definition lives in the docs ([define / data](https://htest.dev/define/#data)) — what follows is patterns that come up in practice.
+`data` is a cascading object accessible to `run` and any setup hook via `this.data`. A child's `data` inherits from its parent's via the prototype chain, so properties set on a parent — even after construction (e.g., in `beforeAll`) — are visible to children. A child's own `data` properties shadow the parent's. The full definition lives in the docs ([define / data](https://htest.dev/define/#data)) — what follows is patterns that come up in practice.
 
 **Good use: shared object, accessed via `this.data`**
 

--- a/src/classes/Test.js
+++ b/src/classes/Test.js
@@ -23,7 +23,7 @@ export default class Test {
 
 		Object.assign(this, test);
 
-		this.data = Object.assign(Object.create(this.parent?.data ?? Object.prototype), this.data);
+		this.data = Object.create(this.parent?.data ?? null, Object.getOwnPropertyDescriptors(this.data));
 		this.originalName = this.name;
 
 		if (typeof this.name === "function") {

--- a/src/classes/Test.js
+++ b/src/classes/Test.js
@@ -23,7 +23,7 @@ export default class Test {
 
 		Object.assign(this, test);
 
-		this.data = Object.assign({}, this.parent?.data, this.data);
+		this.data = Object.assign(Object.create(this.parent?.data ?? Object.prototype), this.data);
 		this.originalName = this.name;
 
 		if (typeof this.name === "function") {

--- a/tests/data.js
+++ b/tests/data.js
@@ -1,0 +1,53 @@
+export default {
+	name: "data inheritance",
+	tests: [
+		{
+			name: "Child own data shadows parent",
+			data: { x: 1 },
+			tests: [
+				{
+					data: { x: 2 },
+					run () {
+						return this.data.x;
+					},
+					expect: 2,
+				},
+			],
+		},
+		{
+			name: "Child data merges with parent data",
+			data: { a: 1 },
+			run () {
+				return { a: this.data.a, b: this.data.b };
+			},
+			tests: [
+				{
+					data: { b: 2 },
+					expect: { a: 1, b: 2 },
+				},
+			],
+		},
+		{
+			name: "Lifecycle hooks set data visible to children",
+			data: { root: "foo" },
+			beforeAll () {
+				this.data.all = 42;
+			},
+			run () {
+				return {
+					root: this.data.root,
+					all: this.data.all,
+					each: this.data.each,
+				};
+			},
+			tests: [
+				{
+					beforeEach () {
+						this.data.each = 99;
+					},
+					tests: [{ expect: { root: "foo", all: 42, each: 99 } }],
+				},
+			],
+		},
+	],
+};


### PR DESCRIPTION
## Summary
- Use `Object.create(parent.data)` instead of `Object.assign({}, parent.data, child.data)` so children see properties set after construction (e.g., in `beforeAll`/`beforeEach`)
- Null prototype when no parent data — avoids inheriting `toString`, `hasOwnProperty`, etc.
- `Object.getOwnPropertyDescriptors()` instead of `Object.assign()` to preserve property descriptors (getters, setters, etc.)
- Add tests for data inheritance, shadowing, merging, and lifecycle hooks
- Update SKILL.md and CLAUDE.md to reflect new semantics

## Test plan
- [x] New `tests/data.js` covers: beforeAll-set data, shadowing, merge, beforeEach
- [x] Full test suite passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)