### PR TITLE
Catch beforeEach() errors instead of crashing

### DIFF
--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -87,11 +87,10 @@ export default class TestResult extends BubblingEventTarget {
 				await this.test.beforeAll?.();
 			}
 
-			await this.test.beforeEach?.apply(this.test, this.test.args);
-
-			let start = performance.now();
-
 			try {
+				await this.test.beforeEach?.apply(this.test, this.test.args);
+
+				let start = performance.now();
 				this.actual = this.test.run ? this.test.run.apply(this.test, this.test.args) : this.test.args[0];
 				this.timeTaken = performance.now() - start;
 

--- a/tests/failing-tests.js
+++ b/tests/failing-tests.js
@@ -17,5 +17,13 @@ export default {
 			arg: 42,
 			expect: 42,
 		},
+		{
+			name: "beforeEach() throws",
+			beforeEach () {
+				throw new Error("setup failed");
+			},
+			run: () => "foo",
+			expect: "foo",
+		},
 	],
 };


### PR DESCRIPTION
## Summary
- Move `beforeEach` invocation inside the existing `try/catch` in `TestResult.run()` so errors are captured as test failures instead of crashing hTest
- `afterEach` now also runs after a `beforeEach` failure (it's in the `finally` block)
- Add a `beforeEach() throws` case to `tests/failing-tests.js`

Closes #137

> [!NOTE]
> `beforeAll` is also called outside `try/catch`, but as group-level setup it arguably *should* fail loudly. Filed separately if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>