### PR TITLE
Changes around `getXXX()`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ src/
 These cascade from parent to child (set in `Test.js` constructor):
 
 ```
-beforeEach  run  afterEach  map  check  getName  args  expect  getExpect  throws  maxTime  maxTimeAsync  skip
+beforeEach  run  afterEach  map  check  getName  getData  args  expect  getExpect  throws  maxTime  maxTimeAsync  skip
 ```
 
 NOT inherited: `beforeAll`, `afterAll`, `name`. `data` inherits via prototype chain (child sees parent's data; own properties shadow parent's).

--- a/SKILL.md
+++ b/SKILL.md
@@ -70,7 +70,7 @@ All properties are optional and inherit from parent to child.
 | `arg`       | Single argument passed to `run`. Can be any value                                                                                                                                                                     |
 | `args`      | Array of arguments passed to `run`. Non-arrays auto-wrapped. `arg` takes precedence                                                                                                                                  |
 | `expect`    | Expected result. Deep equality by default                                                                                                                                                                             |
-| `getExpect` | Function to generate expected value dynamically. Called like `run`: `getExpect.apply(test, args)`. Inherited. `expect` takes precedence if both are set                                                               |
+| `getExpect` | Function to generate expected value dynamically. Called like `run`: `getExpect.apply(test, args)`. Inherited. `expect` takes precedence if both are set. If the getter throws, falls through to default (`args[0]`) |
 | `throws`    | `true` (any error), `false` (asserts no error thrown), Error subclass (`TypeError`), or predicate `e => e.code === "ENOENT"`. Inherited                                                                               |
 
 ### Structure
@@ -78,10 +78,11 @@ All properties are optional and inherit from parent to child.
 | Property      | Description                                                                                                                      |
 | ------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `name`        | Test/group label. Also accessible via `this.name` and `this.parent.name` in `run`. If a function, it's used as `getName` instead |
-| `getName`     | Function to generate names dynamically. Called like `run`: `getName.apply(test, args)`. Inherited (unlike `name`)                |
+| `getName`     | Function to generate names dynamically. Called like `run`: `getName.apply(test, args)`. Inherited (unlike `name`). If the getter throws, falls through to default (first arg or "(No args)") |
 | `description` | Human-readable explanation of the test's intent or edge case. Ignored by the runner                                              |
 | `tests`       | Array of child tests. If present, this is a group (parent); if absent, a leaf test                                               |
-| `data`        | Inherited object accessible via `this.data`. Child inherits parent's data via prototype chain; own properties shadow parent's     |
+| `data`        | Inherited object accessible via `this.data`. Child inherits parent's data via prototype chain; own properties shadow parent's. If a function, it's used as `getData` instead |
+| `getData`     | Function to generate data dynamically. Called like `run`: `getData.apply(test, args)`. Inherited. `data` (literal) takes precedence if both are set. If the getter throws, falls through to empty data |
 | `skip`        | `true` or function returning truthy to skip. Inherited — setting on a parent skips all children                                  |
 
 ### Comparison
@@ -306,6 +307,26 @@ export default {
 			data: { mode: "loose" },
 			tests: [{ arg: "foo", expect: "foo" }],
 		},
+	],
+};
+```
+
+**Good use: `getData` for fresh per-test data**
+
+When each test needs its own fresh data (e.g., an empty array to push into), use `getData` instead of `beforeEach`:
+
+```js
+export default {
+	getData () {
+		return { items: [] };
+	},
+	run () {
+		this.data.items.push(1);
+		return this.data.items.length;
+	},
+	tests: [
+		{ expect: 1 },
+		{ expect: 1 },  // Each test gets its own fresh array
 	],
 };
 ```

--- a/docs/define/README.md
+++ b/docs/define/README.md
@@ -23,6 +23,7 @@ You can access the inherited property via `this.parent` when re-defining either 
 | [`beforeAll`](#setup-teardown) | Function | Code to run before all tests in the group. |
 | [`afterAll`](#setup-teardown) | Function | Code to run after all tests in the group. |
 | [`data`](#data) | Object | Data that will be accessible to the running function as `this.data`. |
+| [`getData`](#data) | Function | A function that generates data dynamically. |
 | [`name`](#name) | String or Function | A string that describes the test. |
 | [`getName`](#name) | Function | A function that generates the test name dynamically. |
 | [`description`](#description) | String | A longer description of the test or group of tests. |
@@ -71,6 +72,29 @@ You can define a single `beforeEach` or `afterEach` function on a parent or ance
 A test’s data is merged with its parent’s data, so you can define common data at a higher level and override it where needed.
 It is useful for differentiating the behavior of `run()` across groups of tests without having to redefine it or pass repetitive arguments.
 
+`data` can also be a *data generator* function.
+It is called with the same context and arguments as `run()` and returns an object whose properties are merged onto `this.data`.
+You can also explicitly provide a function, via `getData`.
+In fact, if `data` is a function, it gets rewritten as `getData` internally.
+
+If both `data` (as a literal object) and `getData` are defined, `data` wins.
+
+`getData` is useful for providing fresh per-test data without `beforeEach()`:
+
+```js
+{
+    getData () { return { items: [] }; },
+    run () {
+        this.data.items.push(1);
+        return this.data.items.length;
+    },
+    tests: [
+        { expect: 1 },
+        { expect: 1 },  // Each test gets its own fresh array
+    ],
+}
+```
+
 ## Describing the test
 
 ### Names and name generators (`name` and `getName()`) { #name }
@@ -90,6 +114,9 @@ Name generators are useful for providing a default name for tests, that you can 
 You may find `this.level` useful in the name generator, as it tells you how deep in the hierarchy the test is, allowing you to provide depth-sensitive name patterns.
 
 If no name is provided, it defaults to the first argument passed to `run`, if any.
+
+If `getName()` throws an error (e.g. by accessing `this.run` on a group with no `run`), the error is caught and the name falls through to its default.
+This allows defining a `getName` that only works in certain contexts without crashing the test tree.
 
 ### Description (`description`) { #description }
 
@@ -117,6 +144,8 @@ The expected result can also be generated dynamically via `getExpect`.
 It is called with the same context and arguments as `run()` and returns the expected result.
 
 If both `expect` and `getExpect` are defined, `expect` wins.
+
+If `getExpect()` throws an error, the error is caught and `expect` falls through to its default (`args[0]`).
 
 ### Error-based criteria (`throws`) { #throws }
 

--- a/src/classes/Test.js
+++ b/src/classes/Test.js
@@ -23,6 +23,11 @@ export default class Test {
 
 		Object.assign(this, test);
 
+		if (typeof this.data === "function") {
+			this.getData = this.data;
+			this.data = {};
+		}
+
 		this.data = Object.create(
 			this.parent?.data ?? null,
 			Object.getOwnPropertyDescriptors(this.data),
@@ -31,6 +36,7 @@ export default class Test {
 
 		if (typeof this.name === "function") {
 			this.getName = this.name;
+			delete this.name;
 		}
 
 		// Inherit properties from parent
@@ -43,6 +49,7 @@ export default class Test {
 				"map",
 				"check",
 				"getName",
+				"getData",
 				"args",
 				"expect",
 				"getExpect",
@@ -81,11 +88,23 @@ export default class Test {
 			this.args = [];
 		}
 
+		if (this.getData && Object.keys(this.data).length === 0) {
+			try {
+				let data = this.getData.apply(this, this.args);
+				Object.defineProperties(this.data, Object.getOwnPropertyDescriptors(data));
+			}
+			catch {}
+		}
+
 		if (!this.name) {
 			if (this.getName) {
-				this.name = this.getName.apply(this, this.args);
+				try {
+					this.name = this.getName.apply(this, this.args);
+				}
+				catch {}
 			}
-			else if (this.isTest) {
+
+			if (!this.name && this.isTest) {
 				this.name = this.args.length > 0 ? stringify(this.args[0]) : "(No args)";
 			}
 		}
@@ -98,9 +117,13 @@ export default class Test {
 
 		if (!("expect" in this)) {
 			if (this.getExpect) {
-				this.expect = this.getExpect.apply(this, this.args);
+				try {
+					this.expect = this.getExpect.apply(this, this.args);
+				}
+				catch {}
 			}
-			else {
+
+			if (!("expect" in this)) {
 				this.expect = this.args[0];
 			}
 		}

--- a/tests/data.js
+++ b/tests/data.js
@@ -49,5 +49,98 @@ export default {
 				},
 			],
 		},
+		{
+			name: "getData",
+			tests: [
+				{
+					name: "Called with test args",
+					getData (x) {
+						return { doubled: x * 2 };
+					},
+					run () {
+						return this.data.doubled;
+					},
+					tests: [{ arg: 5, expect: 10 }],
+				},
+				{
+					name: "Fresh data per test",
+					getData () {
+						return { items: [] };
+					},
+					run () {
+						this.data.items.push("foo");
+						return this.data.items.length;
+					},
+					tests: [{ expect: 1 }, { expect: 1 }],
+				},
+				{
+					name: "Function shorthand",
+					data () {
+						return { x: 42 };
+					},
+					run () {
+						return this.data.x;
+					},
+					tests: [{ expect: 42 }],
+				},
+				{
+					name: "Literal data wins over inherited getData",
+					getData () {
+						return { x: "generated" };
+					},
+					tests: [
+						{
+							data: { x: "literal" },
+							run () {
+								return this.data.x;
+							},
+							expect: "literal",
+						},
+					],
+				},
+				{
+					name: "Merges with parent data",
+					data: { parent: 1 },
+					tests: [
+						{
+							getData () {
+								return { child: 2 };
+							},
+							run () {
+								return {
+									parent: this.data.parent,
+									child: this.data.child,
+								};
+							},
+							expect: { parent: 1, child: 2 },
+						},
+					],
+				},
+				{
+					name: "Preserves accessor descriptors",
+					getData () {
+						return {
+							get items () {
+								return [];
+							},
+						};
+					},
+					run () {
+						return this.data.items !== this.data.items;
+					},
+					expect: true,
+				},
+				{
+					name: "Getter failure falls through to empty data",
+					getData () {
+						throw new Error("Fail");
+					},
+					run () {
+						return this.data;
+					},
+					expect: {},
+				},
+			],
+		},
 	],
 };

--- a/tests/getters.js
+++ b/tests/getters.js
@@ -1,0 +1,102 @@
+import Test from "../src/classes/Test.js";
+
+export default {
+	name: "Getters",
+	tests: [
+		{
+			name: "getName()",
+			run () {
+				return this.name;
+			},
+			tests: [
+				{
+					name: "Called with test args",
+					getName (x) {
+						return "Test " + x;
+					},
+					tests: [{ arg: "foo", expect: "Test foo" }],
+				},
+				{
+					name: "Explicit name wins over getName",
+					getName () {
+						return "generated";
+					},
+					tests: [{ name: "explicit", expect: "explicit" }],
+				},
+				{
+					name: "Failure falls through to default name (args[0])",
+					getName () {
+						throw new Error();
+					},
+					tests: [{ arg: 42, expect: "42" }],
+				},
+				{
+					name: "name() function shorthand",
+					run () {
+						let t = new Test({
+							name () {
+								return "group " + this.level;
+							},
+							tests: [{ arg: 42 }],
+						});
+						return { parent: t.name, child: t.tests[0].name };
+					},
+					expect: { parent: "group 0", child: "group 1" },
+				},
+				{
+					name: "Failure on group with no run() does not crash children (issue #119)",
+					run () {
+						let t = new Test({
+							getName () {
+								return this.run.name + "()";
+							},
+							tests: [
+								{
+									run: function foo () {
+										return 42;
+									},
+									arg: "foo",
+									expect: 42,
+								},
+							],
+						});
+						return t.tests[0].name;
+					},
+					expect: "foo()",
+				},
+			],
+		},
+		{
+			name: "getExpect()",
+			tests: [
+				{
+					name: "Called with test args",
+					getExpect (x) {
+						return x * 2;
+					},
+					run (x) {
+						return x * 2;
+					},
+					tests: [{ arg: 5 }],
+				},
+				{
+					name: "Explicit expect wins over getExpect",
+					getExpect () {
+						return "generated";
+					},
+					run () {
+						return "explicit";
+					},
+					tests: [{ arg: "foo", expect: "explicit" }],
+				},
+				{
+					name: "Failure falls through to default expect (args[0])",
+					getExpect () {
+						throw new Error();
+					},
+					tests: [{ args: ["foo", "bar"], expect: "foo" }],
+				},
+			],
+		},
+	],
+};


### PR DESCRIPTION
## Summary
- Add `getData()` option for dynamic/lazy data generation at construction time
- Fix `getName()` crash on groups without `run` by adding try/catch to all getters
- Fix `name: fn` shorthand not clearing `this.name` on the defining group
- Add `data: fn` shorthand (parallel to `name: fn`)
- Add missed tests.

## Test plan
- [x] `tests/getters.js`: 8 tests for getName + getExpect (declarative + construction)
- [x] `tests/data.js`: 8 new getData tests added to existing data test file
- [x] Full suite passes, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #119. Closes #135.