### PR TITLE
Handle AssertionError as failure, not error

### DIFF
--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -121,6 +121,11 @@ export default class TestResult extends BubblingEventTarget {
 					}
 				}
 				catch (e) {
+					// Duck-type assertion errors (Node assert, Chai, etc.) — use their actual/expected for diffs
+					if ("actual" in e) {
+						this.actual = e.actual;
+						this.test.expect = e.expected;
+					}
 					this.error = e;
 				}
 			}
@@ -374,7 +379,8 @@ export default class TestResult extends BubblingEventTarget {
 		}
 
 		if (!ret.pass) {
-			if (this.error) {
+			// Assertion errors have `.actual` — show diff instead of raw error dump
+			if (this.error && !("actual" in this.error)) {
 				ret.details.push(`Got error ${this.error}
 ${this.error.stack}`);
 			}

--- a/tests/errors.js
+++ b/tests/errors.js
@@ -229,5 +229,20 @@ export default {
 			},
 			expect: true,
 		},
+		{
+			name: "AssertionError treated as failure (issue #114)",
+			skip: typeof globalThis.process === "undefined",
+			async run () {
+				let { strict: assert } = await import("node:assert");
+				let result = await runTest({
+					run () {
+						assert.equal("hello".toUpperCase(), "hello");
+					},
+					expect: "HELLO",
+				});
+				return { actual: result.actual, expected: result.test.expect, pass: result.pass };
+			},
+			expect: { actual: "HELLO", expected: "hello", pass: false },
+		},
 	],
 };


### PR DESCRIPTION
## Summary
- Treat assertion errors (Node `assert`, Chai, etc.) as test failures with proper diffs instead of raw error dumps
- Duck-type via `"actual" in e` to support multiple assertion libraries
- Extract both `actual` and `expected` from the error for diff output
- Always fail when an assertion throws, regardless of hTest's own `check()` result

Closes #114

## Test plan
- [x] New test in `tests/errors.js` verifies `actual` and `expected` are extracted from the assertion error and the test fails
- [x] Full suite passes (88/88)

🤖 Generated with [Claude Code](https://claude.com/claude-code)