### PR TITLE
Show source file paths in CLI test output

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ The CLI output with test results is built as an _interactive tree_ that starts c
 - <kbd>Ctrl</kbd>+<kbd>←</kbd> — "Collapse Subtree" (including the current group)
 - <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>→</kbd> — "Expand All"
 - <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>←</kbd> — "Collapse All"
+- <kbd>o</kbd> — "Open Source File" of the current group (or <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+click the displayed path in supporting terminals)
 
 ## AI Agent Integration
 

--- a/src/classes/Test.js
+++ b/src/classes/Test.js
@@ -16,6 +16,7 @@ const INHERITED_PROPS = [
 	"maxTime",
 	"maxTimeAsync",
 	"skip",
+	"file",
 ];
 
 /**

--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -516,6 +516,18 @@ ${this.error.stack}`);
 			ret.push(`<dim>(${formatDuration(this.timeTaken)})</dim>`);
 		}
 
+		// Show source file path for groups that have their own file (not inherited from parent)
+		if (this.test.file && this.test.file !== this.test.parent?.file) {
+			let { label, path } = this.test.file;
+			if (o?.format === "rich" && path) {
+				// OSC 8 terminal hyperlink. See https://en.wikipedia.org/wiki/ANSI_escape_code#Operating_System_Command_sequences
+				ret.push(`<dim>\x1b]8;;${path}\x07${label}\x1b]8;;\x07</dim>`);
+			}
+			else {
+				ret.push(`<dim>${label}</dim>`);
+			}
+		}
+
 		ret = ret.join(" ");
 
 		return o?.format === "rich" ? ret : stripFormatting(ret);

--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -516,8 +516,12 @@ ${this.error.stack}`);
 			ret.push(`<dim>(${formatDuration(this.timeTaken)})</dim>`);
 		}
 
-		// Show source file path for groups that have their own file (not inherited from parent)
-		if (this.test.file && this.test.file !== this.test.parent?.file) {
+		// Show the source file path for groups that have their own file (not inherited from parent), but only
+		// when the group is expanded or has failing/skipped tests — a path on every passing file is just noise.
+		// `=== false` (not `!collapsed`): in CI mode `collapsed` is undefined, so it must fall through to the
+		// fail/skip check rather than count as expanded.
+		let showFile = this.test.file && this.test.file !== this.test.parent?.file;
+		if (showFile && (this.collapsed === false || stats.fail > 0 || stats.skipped > 0)) {
 			let { label, path } = this.test.file;
 			if (o?.format === "rich" && path) {
 				// OSC 8 terminal hyperlink. See https://en.wikipedia.org/wiki/ANSI_escape_code#Operating_System_Command_sequences

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -1,4 +1,5 @@
 // Native Node packages
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -97,11 +98,20 @@ async function getTestsIn (dir) {
 	let paths = filenames.map(name => path.join(cwd, dir, name));
 
 	return Promise.all(
-		paths.map(path =>
-			import(pathToFileURL(path)).then(
-				module => module.default,
+		paths.map((filePath, i) =>
+			import(pathToFileURL(filePath)).then(
+				module => {
+					let test = module.default ?? module;
+					if (test && typeof test === "object" && Object.isExtensible(test)) {
+						test.file = {
+							label: path.join(dir, filenames[i]), // relative path displayed as link text
+							path: pathToFileURL(filePath).href,
+						};
+					}
+					return test;
+				},
 				err => {
-					console.error(`Error importing tests from ${path}:`, err);
+					console.error(`Error importing tests from ${filePath}:`, err);
 				},
 			)),
 	);
@@ -131,8 +141,19 @@ export default {
 					return import(pathToFileURL(p)).then(m => m.default ?? m);
 				});
 			});
+			let tests = await Promise.all(modules);
 
-			return Promise.all(modules);
+			// Tag test files with source paths (modules already cached, so getTestsIn is just a lookup)
+			await  (async function addSources(dir) {
+				await getTestsIn(dir);
+				for (let entry of fs.readdirSync(dir, { withFileTypes: true })) {
+					if (entry.isDirectory()) {
+						await addSources(path.join(dir, entry.name));
+					}
+				}
+			})(path.dirname(location));
+
+			return tests;
 		}
 	},
 	setup () {
@@ -166,6 +187,7 @@ Use <b>↑</b> and <b>↓</b> arrow keys to navigate groups of tests, <b>→</b>
 Use <b>Ctrl+↑</b> and <b>Ctrl+↓</b> to go to the first or last child group of the current group.
 To expand or collapse the current group and all its subgroups, use <b>Ctrl+→</b> and <b>Ctrl+←</b>.
 Press <b>Ctrl+Shift+→</b> and <b>Ctrl+Shift+←</b> to expand or collapse all groups, regardless of the current group.
+Press <b>o</b> to open the source file of the current group.
 Use <b>any other key</b> to quit interactive mode.
 `;
 				hint = format(hint);
@@ -274,6 +296,25 @@ Use <b>any other key</b> to quit interactive mode.
 						}
 						else if (active.collapsed === true) {
 							active.collapsed = false;
+							render(root, options);
+						}
+					}
+					else if (name === "o") {
+						let file = active.test?.file?.path;
+						if (file) {
+							try {
+								if (process.platform === "win32") {
+									execFileSync("cmd", ["/c", "start", "", file], {
+										stdio: "inherit",
+									});
+								}
+								else {
+									let command =
+										process.platform === "darwin" ? "open" : "xdg-open";
+									execFileSync(command, ["--", file], { stdio: "inherit" });
+								}
+							}
+							catch {}
 							render(root, options);
 						}
 					}

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -2,7 +2,7 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import * as readline from "node:readline";
 
 // Dependencies
@@ -98,20 +98,11 @@ async function getTestsIn (dir) {
 	let paths = filenames.map(name => path.join(cwd, dir, name));
 
 	return Promise.all(
-		paths.map((filePath, i) =>
-			import(pathToFileURL(filePath)).then(
-				module => {
-					let test = module.default ?? module;
-					if (test && typeof test === "object" && Object.isExtensible(test)) {
-						test.file = {
-							label: path.join(dir, filenames[i]), // relative path displayed as link text
-							path: pathToFileURL(filePath).href,
-						};
-					}
-					return test;
-				},
+		paths.map(path =>
+			import(pathToFileURL(path)).then(
+				module => module.default,
 				err => {
-					console.error(`Error importing tests from ${filePath}:`, err);
+					console.error(`Error importing tests from ${path}:`, err);
 				},
 			)),
 	);
@@ -126,9 +117,26 @@ export default {
 		},
 	},
 	resolveLocation: async function (location) {
-		if (fs.statSync(location).isDirectory()) {
+		let loadedFiles = new Set();
+
+		// Watch every module load to tag each test's source file. registerHooks (Node ≥ 22.15) catches
+		// static and dynamic imports. Dynamic import so older Node doesn't SyntaxError on the missing
+		// export; the ?. below makes tagging a no-op there.
+		let { registerHooks } = await import("node:module");
+		let hook = registerHooks?.({
+			load (url, context, nextLoad) {
+				if (url.startsWith("file:") && !url.includes("/node_modules/")) {
+					loadedFiles.add(url);
+				}
+				return nextLoad(url, context);
+			},
+		});
+
+		let tests;
+		let isDirectory = fs.statSync(location).isDirectory();
+		if (isDirectory) {
 			// Directory provided, fetch all files
-			return getTestsIn(location);
+			tests = await getTestsIn(location);
 		}
 		else {
 			// Probably a glob
@@ -141,20 +149,29 @@ export default {
 					return import(pathToFileURL(p)).then(m => m.default ?? m);
 				});
 			});
-			let tests = await Promise.all(modules);
-
-			// Tag test files with source paths (modules already cached, so getTestsIn is just a lookup)
-			await  (async function addSources(dir) {
-				await getTestsIn(dir);
-				for (let entry of fs.readdirSync(dir, { withFileTypes: true })) {
-					if (entry.isDirectory()) {
-						await addSources(path.join(dir, entry.name));
-					}
-				}
-			})(path.dirname(location));
-
-			return tests;
+			tests = await Promise.all(modules);
 		}
+
+		hook?.deregister();
+
+		// Tag each module's default with its source file. Re-imports return the cached namespace — no I/O.
+		await Promise.all(
+			[...loadedFiles].map(async url => {
+				let module = await import(url);
+				let test = module.default ?? module;
+				if (test && typeof test === "object" && Object.isExtensible(test) && !test.file) {
+					test.file = {
+						label: path.relative(
+							isDirectory ? location : path.dirname(location),
+							fileURLToPath(url),
+						),
+						path: url,
+					};
+				}
+			}),
+		);
+
+		return tests;
 	},
 	setup () {
 		process.env.NODE_ENV = "test";

--- a/src/format-console.js
+++ b/src/format-console.js
@@ -52,6 +52,8 @@ let tags = [
 	`</bg>`,
 ];
 let tagRegex = RegExp(tags.flat().join("|"), "gi");
+// Matches OSC 8 terminal hyperlinks, captures display text
+let osc8Regex = RegExp(String.raw`\x1b]8;;[^\x07]*\x07(.*?)\x1b]8;;\x07`, "g");
 
 function getCSS (active, colorStack, bgStack, mode) {
 	let parts = [];
@@ -145,7 +147,7 @@ export default function format (str) {
 }
 
 export function stripFormatting (str) {
-	return str.replace(tagRegex, "");
+	return str.replace(tagRegex, "").replace(osc8Regex, "$1");
 }
 
 // /**


### PR DESCRIPTION
Closes #140

## Summary

- `resolveLocation` registers a `load` hook (`registerHooks`, Node ≥ 22.15) that captures every imported file URL — static and dynamic alike. After the entry point loads, each module's default export is tagged with `{ label, path }`.
- `file` is inherited via `INHERITED_PROPS` so children share the group's source.
- `getSummary()` renders the label as an OSC 8 terminal hyperlink; `stripFormatting` strips the escape for CI/non-TTY. In supporting terminals, <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+click on the path opens the file.
- Interactive mode: <kbd>o</kbd> opens the current group's source file via the platform opener (`open`/`xdg-open`/`cmd start`).

<img width="881" height="758" alt="image" src="https://github.com/user-attachments/assets/f7a2d7f4-5b01-4d0c-a893-fdc483f2098c" />

## Notes

- On Node < 22.15, `registerHooks` is `undefined` and tagging silently no-ops — tests still run, file paths simply don't appear.
- The hook is registered per `resolveLocation` call and `deregister()`-ed after the imports finish, so no module-level state and no leaks across calls.

## Tested

- hTest's own suite: flat directory + index aggregation (`npm test`, `npx htest tests/`)
- [nudeui/element](https://github.com/nudeui/element): nested index files (`test/plugins/props/*`, etc.)
- Single file: `npx htest tests/check.js` — verified no sibling files imported (sentinel side-effect)
- CI output: no leaked OSC 8 escape sequences

## Test plan

- [x] `npm test -- --ci --verbose` — file paths visible on group lines
- [x] `npx htest tests/` — per-file paths in directory mode
- [x] `npx htest tests/check.js` — path on root group; siblings untouched
- [x] Pipe output: `npm test -- --ci --verbose | cat` — no escape sequences
- [x] Interactive mode: press `o` on a group — file opens in default app
- [x] <kbd>Cmd</kbd>+click on path in iTerm2 — opens file in default app