### PR TITLE
Require exact length for array equality (#156)

### DIFF
--- a/src/check.js
+++ b/src/check.js
@@ -58,7 +58,7 @@ export function deep (check = (a, b) => a === b) {
 		}
 
 		if (Array.isArray(expect)) {
-			if (!Array.isArray(actual) || actual.length < expect.length) {
+			if (!Array.isArray(actual) || actual.length !== expect.length) {
 				return false;
 			}
 

--- a/tests/check.js
+++ b/tests/check.js
@@ -26,6 +26,26 @@ export default {
 			],
 		},
 		{
+			name: "equals()",
+			run: check.equals,
+			tests: [
+				{
+					name: "Equal arrays",
+					args: [
+						[13, 15],
+						[13, 15],
+					],
+					expect: true,
+				},
+				{
+					name: "Arrays of different length",
+					description: "Regression for #156 — `expect: []` used to match any array",
+					args: [[1, 0], []],
+					expect: false,
+				},
+			],
+		},
+		{
 			name: "subset()",
 			run: check.subset,
 			tests: [
@@ -59,7 +79,7 @@ export default {
 						[1, 2, 3],
 						[1, 2],
 					],
-					expect: true,
+					expect: false,
 				},
 				{
 					name: "Array with fewer elements missing first argument",
@@ -67,7 +87,7 @@ export default {
 						[1, 2, 3],
 						[, 2],
 					],
-					expect: true,
+					expect: false,
 				},
 				{
 					args: [


### PR DESCRIPTION
`equals()` compared arrays with a prefix match: it only checked that `actual` was at least as long as `expect`, so `expect: []` matched any array and trailing extra elements were ignored — tests passed when they shouldn't.

Fix: compare array length with `!==` instead of `<`.

**Breaking:** arrays must now match `expect` exactly in length, under both `equals` and `subset`. Existing tests using a shorter/prefix `expect` array will now (correctly) fail.

Closes #156.