### PR TITLE
Fix missing output for single tests and barrel file imports

### DIFF
--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -559,6 +559,7 @@ ${this.error.stack}`);
 			ret.push(this.getSummary(o));
 		}
 		else if (
+			!this.parent ||
 			this.pass === false ||
 			(this.skipped && this.error) ||
 			this.messages?.length > 0 ||

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -102,15 +102,17 @@ async function getTestsIn (dir) {
 	let cwd = process.cwd();
 	let paths = filenames.map(name => path.join(cwd, dir, name));
 
-	return Promise.all(
-		paths.map(path =>
-			import(pathToFileURL(path)).then(
-				module => module.default,
-				err => {
-					console.error(`Error importing tests from ${path}:`, err);
-				},
-			)),
-	);
+	return (
+		await Promise.all(
+			paths.map(path =>
+				import(pathToFileURL(path)).then(
+					module => module.default ?? Object.values(module),
+					err => {
+						console.error(`Error importing tests from ${path}:`, err);
+					},
+				)),
+		)
+	).flat();
 }
 
 export default {
@@ -160,10 +162,10 @@ export default {
 				paths = getType(paths) === "string" ? [paths] : paths;
 				return paths.map(p => {
 					p = path.join(process.cwd(), p);
-					return import(pathToFileURL(p)).then(m => m.default ?? m);
+					return import(pathToFileURL(p)).then(m => m.default ?? Object.values(m));
 				});
 			});
-			tests = await Promise.all(modules);
+			tests = (await Promise.all(modules)).flat();
 		}
 
 		hook?.deregister();


### PR DESCRIPTION
## Summary
- Root-level single tests (no `tests` property) produced no output because `toString()` only showed summaries for groups and results for failing tests — a passing root single test matched neither condition
- Barrel files (only named exports, no default) were silently ignored because the module namespace was passed through as-is — now both resolution paths in `env/node.js` extract named exports via `Object.values()` and `.flat()` the result

## Test plan
- [x] `npx htest tests/default-single.js` now shows `PASS single default export (0.03 ms)`
- [x] Failing single test shows `FAIL` with diff details
- [x] `npm test` still passes (91/91)
- [x] Barrel file (xtensible `test/index.js`) resolves all 4 test groups (30 tests)
- [x] Single test imported into a group (nude-element) renders correctly as a child — no spurious summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)