### PR TITLE
Add `skip: "fail"` soft skip — run test, treat failure as skipped, closes #161

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -85,6 +85,8 @@ All properties are optional and inherit from parent to child.
 | `getData`     | Function to generate data dynamically. Called like `run`: `getData.apply(test, args)`. Inherited. `data` (literal) takes precedence if both are set. If the getter throws, falls through to empty data |
 | `skip`        | Any truthy value to skip. Can be an expression evaluated at load time, e.g. `skip: !globalThis.structuredClone`. Inherited — setting on a parent skips all children |
 
+`skip: "fail"` runs the test but treats failure as skipped (the result is still shown). A passing test counts as a regular pass. Useful for marking nice-to-have tests — progress is visible without breaking CI.
+
 ### Comparison
 
 | Property | Description                                                                                                           |

--- a/docs/define/README.md
+++ b/docs/define/README.md
@@ -37,7 +37,7 @@ Tests at the same nesting level run **in parallel**, so don't rely on execution 
 | [`maxTimeAsync`](#maxtime) | Number | The maximum time (in ms) that the test should take to resolve. |
 | [`map`](#map) | Function | A mapping function to apply to the result and expected value before comparing them. |
 | [`check`](#check) | Function or Object | A custom function or options object for comparing the result with the expected value. |
-| [`skip`](#skip) | Any | Any truthy value skips the test(s). |
+| [`skip`](#skip) | Any | Any truthy value skips the test(s). `"fail"` runs the test but treats failure as skipped. |
 </div>
 
 ## Defining the test
@@ -303,3 +303,19 @@ Often, we have written tests for parts of the API that are not yet implemented.
 It doesn't make sense to remove these tests, but they should also not be making the testsuite fail.
 Any truthy value skips the test. `skip: true` is the simplest form, but you can use any expression evaluated at module load time, e.g. `skip: !globalThis.structuredClone`.
 The number of skipped tests will be shown separately.
+
+#### Soft skip (`skip: "fail"`) { #skip-fail }
+
+`skip: "fail"` marks a test as a nice-to-have: the test runs, but if it fails, it is treated as skipped rather than a real failure.
+If it passes, it counts as a regular pass.
+This lets you see progress as previously failing tests start passing, without manually removing `skip` markers.
+
+```js
+{
+	name: "New API (not yet stable)",
+	skip: "fail",
+	tests: [
+		{ run: () => newAPI("foo"), expect: "bar" },
+	],
+}
+```

--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -230,7 +230,7 @@ export default class TestResult extends BubblingEventTarget {
 				}
 
 				if (this.test.isTest) {
-					if (this.test.skip) {
+					if (this.test.skip && this.test.skip !== "fail") {
 						this.skip();
 					}
 					else if (error) {
@@ -271,6 +271,10 @@ export default class TestResult extends BubblingEventTarget {
 		}
 		else {
 			Object.assign(this, this.evaluateResult());
+		}
+
+		if (test.skip === "fail" && !this.pass) {
+			this.skipped = true;
 		}
 
 		this.dispatchEvent(new Event("done", { bubbles: true }));
@@ -561,7 +565,7 @@ ${this.error.stack}`);
 		else if (
 			!this.parent ||
 			this.pass === false ||
-			(this.skipped && this.error) ||
+			(this.skipped && (this.error || this.test.skip === "fail")) ||
 			this.messages?.length > 0 ||
 			o?.verbose
 		) {

--- a/tests/errors.js
+++ b/tests/errors.js
@@ -230,6 +230,43 @@ export default {
 			expect: true,
 		},
 		{
+			name: `skip: "fail" (soft skip)`,
+			async run (test) {
+				let result = await runTest({ skip: "fail", ...test });
+				return { skipped: result.skipped, pass: result.pass };
+			},
+			tests: [
+				{
+					name: "Failing test is skipped",
+					arg: { run: () => "wrong", expect: "right" },
+					expect: { skipped: true, pass: false },
+				},
+				{
+					name: "Passing test is a regular pass",
+					arg: { run: () => "foo", expect: "foo" },
+					expect: { skipped: undefined, pass: true },
+				},
+				{
+					name: "Inherited from parent",
+					async run () {
+						let test = new Test({
+							skip: "fail",
+							tests: [
+								{ run: () => "wrong", expect: "right" },
+								{ run: () => "ok", expect: "ok" },
+							],
+						});
+						let result = new TestResult(test);
+						result.runAll();
+						await result.finished;
+						let { pass, skipped } = result.stats;
+						return { pass, skipped };
+					},
+					expect: { pass: 1, skipped: 1 },
+				},
+			],
+		},
+		{
 			name: "AssertionError treated as failure (issue #114)",
 			skip: typeof globalThis.process === "undefined",
 			async run () {


### PR DESCRIPTION
When skip is set to "fail", the test runs normally. If it fails, it flips to skipped (result still shown). If it passes, it counts as a regular pass. Inherits like regular skip.