### PR TITLE
Add --watch flag for automatic test re-runs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -481,6 +481,7 @@ npx htest test/               # All JS in directory (not recursive, skips index*
 npx htest test/index.js       # Use index files for recursive aggregation
 npx htest test/file.js --ci       # Force non-interactive mode (automatic in non-TTY environments)
 npx htest test/file.js --verbose  # Show all tests, including passing
+npx htest test/file.js --watch    # Re-run automatically on file changes
 ```
 
 ---

--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -230,7 +230,10 @@ export default class TestResult extends BubblingEventTarget {
 				}
 
 				if (this.test.isTest) {
-					if (this.test.skip && this.test.skip !== "fail") {
+					if (this.options.signal?.aborted) {
+						this.skip();
+					}
+					else if (this.test.skip && this.test.skip !== "fail") {
 						this.skip();
 					}
 					else if (error) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,6 +11,7 @@ import { getConfig, loadScripts } from "./config.js";
  * Supported flags:
  * --ci         Run in continuous integration mode (disables interactive features)
  * --verbose    Verbose output (show all tests, not just failed, skipped, or tests with intercepted console messages)
+ * --watch      Watch the test location for file changes and re-run automatically
  *
  * @param {object} [options] Same as `run()` options, but command line arguments take precedence
  */
@@ -22,7 +23,7 @@ export default async function cli (options = {}) {
 
 	let argv = process.argv.slice(2);
 
-	const flags = ["ci", "verbose"];
+	const flags = ["ci", "verbose", "watch"];
 	for (let flag of flags) {
 		let flagIndex = argv.indexOf("--" + flag);
 		if (flagIndex !== -1) {

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -115,6 +115,20 @@ async function getTestsIn (dir) {
 	).flat();
 }
 
+let controller = new AbortController();
+let debounceTimer;
+let watcher;
+
+function rerun (options) {
+	controller.abort();
+	controller = new AbortController();
+	options.signal = controller.signal;
+	process.stdin.removeAllListeners("keypress");
+	logUpdate.clear();
+	version++;
+	run(options.location, options);
+}
+
 export default {
 	name: "Node.js",
 	defaultOptions: {
@@ -189,8 +203,30 @@ export default {
 
 		return tests;
 	},
-	setup () {
+	setup (options) {
 		process.env.NODE_ENV = "test";
+
+		if (!options.watch || watcher) {
+			return;
+		}
+
+		let target = path.resolve(options.location);
+		let watchDir = fs.statSync(target, { throwIfNoEntry: false })?.isDirectory()
+			? target
+			: path.dirname(target);
+
+		watcher = fs.watch(watchDir, { recursive: true }, (eventType, filename) => {
+			if (
+				!filename ||
+				filename.includes("node_modules") ||
+				!filenamePatterns.include.test(filename)
+			) {
+				return;
+			}
+
+			clearTimeout(debounceTimer);
+			debounceTimer = setTimeout(() => rerun(options), 200);
+		});
 	},
 	done (result, options, event, root) {
 		// Interactive mode requires both a TTY stdout (for cursor control) and a TTY stdin (for raw keypress events).
@@ -226,6 +262,7 @@ Press <b>Ctrl+Shift+→</b> and <b>Ctrl+Shift+←</b> to expand or collapse all 
 Press <b>o</b> to open the source file of the current group.
 Press <b>r</b> to re-run all tests (picks up file changes).
 Use <b>any other key</b> to quit interactive mode.
+${options.watch ? "\n<b>Watching for file changes…</b>" : ""}
 `;
 					hint = format(hint);
 					// Why not console.log(hint)? Because we don't want to mess up other console messages produced by tests,
@@ -241,6 +278,7 @@ Use <b>any other key</b> to quit interactive mode.
 				render(root, options);
 
 				let active = root; // active (highlighted) group of tests that can be expanded/collapsed; root by default
+				process.stdin.removeAllListeners("keypress"); // prevent stale listener from an aborted run's done handler
 				process.stdin.on("keypress", (character, key) => {
 					let name = key.name;
 
@@ -357,15 +395,11 @@ Use <b>any other key</b> to quit interactive mode.
 						}
 					}
 					else if (name === "r") {
-						// Re-run, picking up file changes. Remove our keypress listener (the only
-						// one — emitKeypressEvents is the emitter) so the fresh run installs its own.
-						process.stdin.removeAllListeners("keypress");
-						logUpdate.clear();
-						version++;
-						run(options.location, options);
+						rerun(options);
 					}
 					else {
 						// Quit interactive mode on any other key
+						watcher?.close();
 						logUpdate.done();
 						process.exit();
 					}

--- a/src/run.js
+++ b/src/run.js
@@ -75,7 +75,7 @@ export default function run (test, options = {}) {
 	}
 
 	if (env.setup) {
-		env.setup();
+		env.setup(options);
 	}
 
 	if (!(test instanceof Test)) {


### PR DESCRIPTION
## Summary

- Adds `--watch` CLI flag that uses native `fs.watch({ recursive: true })` to watch the test location for file changes and re-run the suite automatically with 200ms debounce
- Uses `AbortController` to signal in-flight runs to stop spawning new tests via the native `skip()` mechanism, preserving `afterAll` lifecycle hooks
- Extracts shared `rerun()` function used by both the R key handler and the file watcher

Closes #163

## Test plan

- [x] `npm test` — 93/93 pass
- [x] `npx htest tests/index.js --watch` — manual verification: file edits trigger re-run, R key works, quit exits cleanly
- [ ] Verify no re-run storms on editor save

🤖 Generated with [Claude Code](https://claude.com/claude-code)