### PR TITLE
Rework interactive mode: alt screen, viewport scrolling, watch integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "0.0.27",
       "license": "MIT",
       "dependencies": {
+        "ansi-escapes": "^7.3.0",
         "diff": "^8.0.4",
         "glob": "^13.0.6",
-        "log-update": "^6.1.0",
-        "oo-ascii-tree": "^1.127.0"
+        "oo-ascii-tree": "^1.127.0",
+        "string-width": "^8.2.1"
       },
       "bin": {
         "htest": "bin/htest.js"
@@ -2031,6 +2032,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^5.0.0"
@@ -2471,12 +2473,6 @@
       "dependencies": {
         "cheerio": "^1.0.0-rc.10"
       }
-    },
-    "node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -3971,25 +3967,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/log-update": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
-      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^7.0.0",
-        "cli-cursor": "^5.0.0",
-        "slice-ansi": "^7.1.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "11.2.7",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
@@ -4162,6 +4139,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4393,6 +4371,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
       "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-function": "^5.0.0"
@@ -5114,6 +5093,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^7.0.0",
@@ -5280,6 +5260,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -5296,49 +5277,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/slugify": {
@@ -5449,7 +5387,6 @@
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
       "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.5.0",
@@ -5810,52 +5747,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/wrappy": {
@@ -7291,6 +7182,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
       "requires": {
         "restore-cursor": "^5.0.0"
       }
@@ -7581,11 +7473,6 @@
       "requires": {
         "cheerio": "^1.0.0-rc.10"
       }
-    },
-    "emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
     },
     "encodeurl": {
       "version": "2.0.0",
@@ -8612,18 +8499,6 @@
         "yoctocolors": "^2.1.1"
       }
     },
-    "log-update": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
-      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
-      "requires": {
-        "ansi-escapes": "^7.0.0",
-        "cli-cursor": "^5.0.0",
-        "slice-ansi": "^7.1.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      }
-    },
     "lru-cache": {
       "version": "11.2.7",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
@@ -8736,7 +8611,8 @@
     "mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.1.5",
@@ -8895,6 +8771,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
       "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
       "requires": {
         "mimic-function": "^5.0.0"
       }
@@ -9372,6 +9249,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
       "requires": {
         "onetime": "^7.0.0",
         "signal-exit": "^4.1.0"
@@ -9475,37 +9353,14 @@
     "signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true
     },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
-    },
-    "slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-      "requires": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-          "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="
-        },
-        "is-fullwidth-code-point": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-          "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-          "requires": {
-            "get-east-asian-width": "^1.3.1"
-          }
-        }
-      }
     },
     "slugify": {
       "version": "1.6.8",
@@ -9578,7 +9433,6 @@
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
       "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
-      "dev": true,
       "requires": {
         "get-east-asian-width": "^1.5.0",
         "strip-ansi": "^7.1.2"
@@ -9810,33 +9664,6 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
-    },
-    "wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "requires": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-          "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="
-        },
-        "string-width": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-          "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-          "requires": {
-            "emoji-regex": "^10.3.0",
-            "get-east-asian-width": "^1.0.0",
-            "strip-ansi": "^7.1.0"
-          }
-        }
-      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -69,9 +69,10 @@
     "typedoc": "^0.28"
   },
   "dependencies": {
+    "ansi-escapes": "^7.3.0",
     "diff": "^8.0.4",
     "glob": "^13.0.6",
-    "log-update": "^6.1.0",
-    "oo-ascii-tree": "^1.127.0"
+    "oo-ascii-tree": "^1.127.0",
+    "string-width": "^8.2.1"
   }
 }

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -252,6 +252,12 @@ async function rerun (options, urls) {
 	run(options.location, { ...options, signal: controller.signal });
 }
 
+process.on("exit", () => {
+	for (let watcher of watchers.values()) {
+		watcher.close();
+	}
+});
+
 export default {
 	name: "Node.js",
 	defaultOptions: {

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -1,16 +1,14 @@
 // Native Node packages
-import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import * as readline from "node:readline";
 
 // Dependencies
-import logUpdate from "log-update";
-import { AsciiTree } from "oo-ascii-tree";
 import { globSync } from "glob";
 
 // Internal modules
+import interactiveTree, { getTree, prepareRerun } from "../interactive-tree.js";
 import format, { stripFormatting } from "../format-console.js";
 import { getType } from "../util.js";
 import run from "../run.js";
@@ -20,74 +18,6 @@ import TestResult from "../classes/TestResult.js";
 // Bumped on each re-run and appended as a query param when importing test files,
 // so dynamic import() bypasses the module cache and reloads fresh code.
 let version = 0;
-
-/**
- * Recursively traverse a subtree starting from `node`
- * and make groups of tests and test with console messages
- * either collapsed or expanded by setting its `collapsed` property.
- * @param {object} node - The root node of the subtree.
- * @param {boolean} collapsed - Whether to collapse or expand the subtree.
- */
-function setCollapsed (node, collapsed = true) {
-	if (node.tests?.length || node.messages?.length) {
-		node.collapsed = collapsed;
-
-		let nodes = [...(node.tests ?? []), ...(node.messages ?? [])];
-		for (let node of nodes) {
-			setCollapsed(node, collapsed);
-		}
-	}
-}
-
-/**
- * Recursively traverse a subtree starting from `node` and return all visible groups of tests or tests with console messages.
- */
-function getVisibleGroups (node, options, groups = []) {
-	groups.push(node);
-
-	if (node.collapsed === false && node.tests?.length) {
-		let tests = node.tests.filter(test => test.toString(options).collapsed !== undefined); // we are interested in groups only
-		for (let test of tests) {
-			getVisibleGroups(test, options, groups);
-		}
-	}
-
-	return groups;
-}
-
-function getTree (msg, i) {
-	if (msg.collapsed !== undefined) {
-		const icons = {
-			collapsed: "▷",
-			expanded: "▽",
-			collapsedHighlighted: "▶︎",
-			expandedHighlighted: "▼",
-		};
-
-		let { collapsed, highlighted, children } = msg;
-
-		let icon = collapsed ? icons.collapsed : icons.expanded;
-		if (highlighted) {
-			icon = `<c green><b>${collapsed ? icons.collapsedHighlighted : icons.expandedHighlighted}</b></c>`;
-			msg = `<b>${msg}</b>`;
-		}
-		msg = icon + " " + msg;
-		msg = new String(msg);
-		msg.collapsed = collapsed;
-		msg.children = collapsed ? [] : children;
-	}
-
-	return new AsciiTree(`</dim>${msg}<dim>`, ...(msg.children?.map(getTree) ?? []));
-}
-
-// Render the tests stats
-function render (root, options = {}) {
-	let messages = root.toString({ ...options, format: options.format ?? "rich" });
-	let tree = getTree(messages).toString();
-	tree = format(tree);
-
-	logUpdate(tree);
-}
 
 // Set up environment for Node
 const filenamePatterns = {
@@ -126,6 +56,7 @@ let controller = new AbortController();
 let debounceTimer;
 let watchers = new Map();
 let loadedFiles = new Set();
+
 /**
  * Files that changed since the last --watch re-run.
  * The watcher collects URLs here; {@link rerun} drains the set on each re-run.
@@ -156,39 +87,7 @@ let hookActive = false;
  */
 let currentRoot;
 
-/**
- * TestResult subtrees replaced during a --watch re-run.
- * When set, {@link done} collapses only these instead of the entire tree.
- * @type {TestResult[] | null}
- */
-let subtrees = null;
-
-let keypressListener;
 let isInteractive;
-
-function saveState (node) {
-	let state = { collapsed: node.collapsed, highlighted: node.highlighted };
-	if (node.tests) {
-		state.children = node.tests.map(saveState);
-	}
-	return state;
-}
-
-function restoreState (node, state) {
-	node.collapsed = state.collapsed;
-	node.highlighted = state.highlighted;
-
-	if (node.tests) {
-		for (let i = 0; i < node.tests.length; i++) {
-			if (state.children?.[i]) {
-				restoreState(node.tests[i], state.children[i]);
-			}
-			else {
-				setCollapsed(node.tests[i]);
-			}
-		}
-	}
-}
 
 function getAffectedFiles (urls) {
 	let rootPath = currentRoot.test.file?.path;
@@ -255,9 +154,6 @@ function syncWatchers (options) {
 }
 
 async function rerun (options, urls) {
-	if (keypressListener) {
-		process.stdin.off("keypress", keypressListener);
-	}
 	version++;
 
 	if (urls && currentRoot?.stats.pending === 0) {
@@ -325,7 +221,7 @@ async function rerun (options, urls) {
 				currentRoot.stats.total += test.testCount;
 				currentRoot.stats.pending += test.testCount;
 
-				results.push({ result, state: saveState(old) });
+				results.push({ result, old });
 			}
 
 			hookActive = false;
@@ -333,20 +229,11 @@ async function rerun (options, urls) {
 
 			if (results.length === 0) {
 				// Only deletions — no tests to run, no done/finish events will fire.
-				let groups = getVisibleGroups(currentRoot, options);
-				if (!groups.some(g => g.highlighted)) {
-					currentRoot.highlighted = true;
-				}
-
-				render(currentRoot, options);
-
-				if (keypressListener) {
-					process.stdin.on("keypress", keypressListener);
-				}
+				interactiveTree(currentRoot, options, { rerun: () => rerun(options) });
 				return;
 			}
 
-			subtrees = results;
+			prepareRerun(results);
 
 			currentRoot.finished = new Promise(resolve =>
 				currentRoot.addEventListener("finish", resolve, { once: true }));
@@ -359,10 +246,8 @@ async function rerun (options, urls) {
 	}
 
 	// Full re-run fallback
-	subtrees = null;
 	controller.abort();
 	controller = new AbortController();
-	logUpdate.clear();
 	// Don't mutate options — the old tree's TestResults need to see the aborted signal.
 	run(options.location, { ...options, signal: controller.signal });
 }
@@ -495,200 +380,7 @@ export default {
 			return;
 		}
 
-		if (subtrees) {
-			for (let { result, state } of subtrees) {
-				restoreState(result, state);
-			}
-		}
-		else {
-			setCollapsed(root); // all groups and console messages are collapsed by default
-		}
-
-		if (root.stats.pending > 0) {
-			render(root, options);
-		}
-		else {
-			let active;
-
-			if (subtrees) {
-				// --watch re-run complete: preserve UI state, just re-attach navigation
-				subtrees = null;
-
-				let groups = getVisibleGroups(root, options);
-				if (!groups.some(g => g.highlighted)) {
-					root.highlighted = true;
-				}
-
-				active = groups.find(g => g.highlighted) ?? root;
-			}
-			else {
-				// Fresh tree: full interactive setup
-				if (version === 0) {
-					// Print the hint once, on the first run. Re-runs keep this committed copy in place
-					// and refresh the tree below it instead of stacking a new hint each time.
-					logUpdate.clear();
-
-					let hint = `
-Use <b>↑</b> and <b>↓</b> arrow keys to navigate groups of tests, <b>→</b> and <b>←</b> to expand and collapse them, respectively.
-Use <b>Ctrl+↑</b> and <b>Ctrl+↓</b> to go to the first or last child group of the current group.
-To expand or collapse the current group and all its subgroups, use <b>Ctrl+→</b> and <b>Ctrl+←</b>.
-Press <b>Ctrl+Shift+→</b> and <b>Ctrl+Shift+←</b> to expand or collapse all groups, regardless of the current group.
-Press <b>o</b> to open the source file of the current group.
-Press <b>r</b> to re-run all tests (picks up file changes).
-Use <b>any other key</b> to quit interactive mode.
-${options.watch ? "\n<b>Watching for file changes…</b>" : ""}
-`;
-					hint = format(hint);
-					// Why not console.log(hint)? Because we don't want to mess up other console messages produced by tests,
-					// especially the async ones.
-					logUpdate(hint);
-					logUpdate.done();
-				}
-
-				readline.emitKeypressEvents(process.stdin);
-				process.stdin.setRawMode(true); // handle keypress events instead of Node
-
-				root.highlighted = true;
-				active = root;
-			}
-
-			render(root, options);
-
-			keypressListener = (character, key) => {
-				let name = key.name;
-
-				if (name === "up") {
-					// Figure out what group of tests is active (and should be highlighted)
-					let groups = getVisibleGroups(root, options);
-
-					if (key.ctrl) {
-						let parent = active.parent;
-						if (parent) {
-							active = groups.filter(group => group.parent === parent)[0]; // the first one from all groups with the same parent
-						}
-					}
-					else {
-						let index = groups.indexOf(active);
-						index = Math.max(0, index - 1); // choose the previous group, but don't go higher than the root
-						active = groups[index];
-					}
-
-					for (let group of groups) {
-						group.highlighted = false;
-					}
-					active.highlighted = true;
-					render(root, options);
-				}
-				else if (name === "down") {
-					let groups = getVisibleGroups(root, options);
-
-					if (key.ctrl) {
-						let parent = active.parent;
-						if (parent) {
-							active = groups.filter(group => group.parent === parent).at(-1); // the last one from all groups with the same parent
-						}
-					}
-					else {
-						let index = groups.indexOf(active);
-						index = Math.min(groups.length - 1, index + 1); // choose the next group, but don't go lower than the last one
-						active = groups[index];
-					}
-
-					for (let group of groups) {
-						group.highlighted = false;
-					}
-					active.highlighted = true;
-					render(root, options);
-				}
-				else if (name === "left") {
-					if (key.ctrl && key.shift) {
-						// Collapse all groups on Ctrl+Shift+←
-						let groups = getVisibleGroups(root, options);
-						for (let group of groups) {
-							group.highlighted = false;
-						}
-
-						setCollapsed(root);
-						active = root;
-						active.highlighted = true;
-						render(root, options);
-					}
-					else if (key.ctrl) {
-						// Collapse the current group and all its subgroups on Ctrl+←
-						setCollapsed(active);
-						render(root, options);
-					}
-					else if (active.collapsed === false) {
-						active.collapsed = true;
-						render(root, options);
-					}
-					else if (active.parent) {
-						// If the current group is collapsed, collapse its parent group
-						let groups = getVisibleGroups(root, options);
-						let index = groups.indexOf(active.parent);
-						active = groups[index];
-						active.collapsed = true;
-
-						for (let group of groups) {
-							group.highlighted = false;
-						}
-						active.highlighted = true;
-						render(root, options);
-					}
-				}
-				else if (name === "right") {
-					if (key.ctrl && key.shift) {
-						// Expand all groups on Ctrl+Shift+→
-						setCollapsed(root, false);
-						render(root, options);
-					}
-					else if (key.ctrl) {
-						// Expand the current group and all its subgroups on Ctrl+→
-						setCollapsed(active, false);
-						render(root, options);
-					}
-					else if (active.collapsed === true) {
-						active.collapsed = false;
-						render(root, options);
-					}
-				}
-				else if (name === "o") {
-					let file = active.test?.file?.path;
-					if (file) {
-						try {
-							if (process.platform === "win32") {
-								execFileSync("cmd", ["/c", "start", "", file], {
-									stdio: "inherit",
-								});
-							}
-							else {
-								let command = process.platform === "darwin" ? "open" : "xdg-open";
-								execFileSync(command, ["--", file], { stdio: "inherit" });
-							}
-						}
-						catch {}
-						render(root, options);
-					}
-				}
-				else if (name === "r") {
-					rerun(options);
-				}
-				else {
-					// Quit interactive mode on any other key
-					for (let watcher of watchers.values()) {
-						watcher.close();
-					}
-					logUpdate.done();
-					process.exit();
-				}
-			};
-			process.stdin.on("keypress", keypressListener);
-		}
-
 		currentRoot = root;
-
-		if (root.stats.fail > 0) {
-			process.exitCode = 1;
-		}
+		interactiveTree(root, options, { rerun: () => rerun(options) });
 	},
 };

--- a/src/interactive-tree.js
+++ b/src/interactive-tree.js
@@ -519,3 +519,12 @@ process.on("exit", () => {
 		fullscreen.toggle(false);
 	}
 });
+
+for (let sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+	process.on(sig, () => {
+		if (process.stdout.isTTY) {
+			fullscreen.toggle(false);
+		}
+		process.exit();
+	});
+}

--- a/src/interactive-tree.js
+++ b/src/interactive-tree.js
@@ -1,0 +1,521 @@
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+import * as readline from "node:readline";
+
+import ansiEscapes from "ansi-escapes";
+import { AsciiTree } from "oo-ascii-tree";
+import stringWidth from "string-width";
+
+import format from "./format-console.js";
+
+// Constants / UI config
+
+const icons = {
+	collapsed: "▷",
+	expanded: "▽",
+	collapsedHighlighted: "▶︎",
+	expandedHighlighted: "▼",
+};
+
+let hint = {
+	full: `Use <b>↑</b> and <b>↓</b> to navigate groups, <b>→</b> and <b>←</b> to expand/collapse.
+<b>Ctrl+↑</b>/<b>↓</b> — first/last in group. <b>Ctrl+→</b>/<b>←</b> — expand/collapse subgroups.
+<b>Ctrl+Shift+→</b>/<b>←</b> — expand/collapse all.
+
+<b>o</b> open source file · <b>r</b> re-run tests · <b>any other key</b> quit.`,
+	compact: `<dim>Press <b>h</b> to toggle help.</dim>`,
+	expanded: false,
+	get text () {
+		return this.expanded ? this.full : this.compact;
+	},
+};
+
+let fullscreen = {
+	active: false,
+	toggle (on) {
+		if (on === this.active) {
+			return;
+		}
+
+		this.active = on;
+		process.stdout.write(
+			on
+				? ansiEscapes.enterAlternativeScreen + ansiEscapes.cursorHide
+				: ansiEscapes.cursorShow + ansiEscapes.exitAlternativeScreen,
+		);
+	},
+};
+
+// Tree building
+
+/**
+ * Convert the message tree from `TestResult.toString()` into a printable ASCII tree.
+ * Also records where the highlighted group lands in the output (`highlight`)
+ * so the viewport knows what to keep visible.
+ * @param {object} msg
+ * @param {object} [highlight]
+ * @param {number} [parent]
+ * @param {object} [state]
+ * @returns {AsciiTree}
+ */
+export function getTree (msg, highlight = {}, parent = -1, state = { line: 0, seek: false }) {
+	let at = state.line;
+	let group = msg.collapsed !== undefined;
+	let highlighted = group && msg.highlighted;
+	let children = msg.collapsed ? [] : msg.children;
+
+	if (group && state.seek && !highlighted) {
+		highlight.next = at;
+		state.seek = false;
+	}
+
+	if (highlighted) {
+		highlight.line = at;
+		highlight.parent = parent;
+		state.seek = true;
+	}
+
+	if (group) {
+		let icon = msg.collapsed ? icons.collapsed : icons.expanded;
+		if (highlighted) {
+			icon = `<c green><b>${msg.collapsed ? icons.collapsedHighlighted : icons.expandedHighlighted}</b></c>`;
+			msg = `<b>${msg}</b>`;
+		}
+		msg = icon + " " + msg;
+	}
+
+	state.line += String(msg).split("\n").length;
+	let nodes = children?.map(child => getTree(child, highlight, group ? at : parent, state)) ?? [];
+
+	if (highlighted) {
+		highlight.end = state.line;
+	}
+
+	// Tree renders inside a dim context; turn dim OFF for content, back ON for tree-drawing chars (├──, └──)
+	return new AsciiTree(`</dim>${msg}<dim>`, ...nodes);
+}
+
+export function setCollapsed (node, collapsed = true) {
+	if (node.tests?.length || node.messages?.length) {
+		node.collapsed = collapsed;
+
+		let nodes = [...(node.tests ?? []), ...(node.messages ?? [])];
+		for (let node of nodes) {
+			setCollapsed(node, collapsed);
+		}
+	}
+}
+
+// Viewport math
+
+/** How many lines fit in the viewport starting at `from`? Returns the index past the last visible line. */
+function getViewportEnd (heights, from, budget) {
+	let to = from,
+		used = 0;
+	while (to < heights.length && used + heights[to] <= budget) {
+		used += heights[to++];
+	}
+	return to;
+}
+
+/** Where should the viewport start to end at `to`? Returns the first line index that fits. */
+function getViewportStart (heights, to, budget) {
+	let from = to,
+		used = 0;
+	while (from > 0 && used + heights[from - 1] <= budget) {
+		used += heights[--from];
+	}
+	return from;
+}
+
+/**
+ * Compute the visible window. Keeps the previous scroll position and only shifts
+ * when the highlighted group would be off-screen — nearby navigation feels stable,
+ * jumping far re-centers naturally.
+ */
+function getViewport ({ heights, highlightStart, highlightEnd, scroll = 0, budget }) {
+	let start = Math.min(scroll, highlightStart);
+
+	if (highlightEnd > getViewportEnd(heights, start, budget)) {
+		start = Math.min(highlightStart, getViewportStart(heights, highlightEnd, budget));
+	}
+
+	return { start, end: Math.max(getViewportEnd(heights, start, budget), start + 1) };
+}
+
+// Session state — reset per fresh root (via `initialized` WeakSet), persisted across done() calls
+
+/** First visible line index in the viewport. */
+let scroll;
+
+/**
+ * Intra-group scroll offset. When a group's expanded content is taller than the viewport,
+ * the extra lines are hidden — up/down page through them before moving to the next group.
+ */
+let offset;
+
+/** Last computed viewport: { highlightStart, next, start, end }. Used by up/down paging. */
+let viewport;
+
+/** The currently highlighted (keyboard-navigable) group. */
+let active;
+
+let resizeListener, keypressListener;
+
+// Watch state
+
+function saveState (node) {
+	let state = { collapsed: node.collapsed, highlighted: node.highlighted };
+	if (node.tests) {
+		state.children = node.tests.map(saveState);
+	}
+	return state;
+}
+
+function restoreState (node, state) {
+	node.collapsed = state.collapsed;
+	node.highlighted = state.highlighted;
+
+	if (node.tests) {
+		for (let i = 0; i < node.tests.length; i++) {
+			if (state.children?.[i]) {
+				restoreState(node.tests[i], state.children[i]);
+			}
+			else {
+				setCollapsed(node.tests[i]);
+			}
+		}
+	}
+}
+
+/**
+ * TestResult subtrees replaced during a --watch partial re-run.
+ * Set by {@link prepareRerun}, consumed by {@link interactiveTree} to restore UI state.
+ * @type {Array | null}
+ */
+let subtrees = null;
+
+export function prepareRerun (results) {
+	subtrees = results.map(({ result, old }) => ({ result, state: saveState(old) }));
+}
+
+// Navigation
+
+/** Collect all groups reachable by keyboard navigation (expanded ancestors). */
+function getNavigableGroups (node, options, groups = []) {
+	groups.push(node);
+
+	if (node.collapsed === false && node.tests?.length) {
+		let tests = node.tests.filter(test => test.toString(options).collapsed !== undefined); // groups only
+		for (let test of tests) {
+			getNavigableGroups(test, options, groups);
+		}
+	}
+
+	return groups;
+}
+
+function handleKeypress (root, options, rerun, key) {
+	let name = key.name;
+
+	if (name === "up") {
+		// Oversized group: page up through its content before moving to the previous group
+		if (!key.ctrl && offset > 0) {
+			offset = Math.max(0, offset - (viewport.end - viewport.start));
+			render(root, options);
+			return;
+		}
+
+		let groups = getNavigableGroups(root, options);
+		offset = 0;
+
+		if (key.ctrl) {
+			let parent = active.parent;
+			if (parent) {
+				active = groups.filter(group => group.parent === parent)[0]; // the first one from all groups with the same parent
+			}
+		}
+		else {
+			let index = groups.indexOf(active);
+			index = Math.max(0, index - 1); // don't go higher than the root
+			active = groups[index];
+		}
+
+		for (let group of groups) {
+			group.highlighted = false;
+		}
+		active.highlighted = true;
+		render(root, options);
+	}
+	else if (name === "down") {
+		// Oversized group: page down through hidden content before advancing to the next group
+		if (!key.ctrl && viewport?.end < viewport?.next) {
+			offset = viewport.end - viewport.highlightStart;
+			render(root, options);
+			return;
+		}
+
+		let groups = getNavigableGroups(root, options);
+		offset = 0;
+
+		if (key.ctrl) {
+			let parent = active.parent;
+			if (parent) {
+				active = groups.filter(group => group.parent === parent).at(-1); // the last one from all groups with the same parent
+			}
+		}
+		else {
+			let index = groups.indexOf(active);
+			index = Math.min(groups.length - 1, index + 1); // don't go lower than the last one
+			active = groups[index];
+		}
+
+		for (let group of groups) {
+			group.highlighted = false;
+		}
+		active.highlighted = true;
+		render(root, options);
+	}
+	else if (name === "left") {
+		offset = 0; // collapsing changes the layout — drop any intra-group scroll
+
+		if (key.ctrl && key.shift) {
+			// Collapse all groups
+			let groups = getNavigableGroups(root, options);
+			for (let group of groups) {
+				group.highlighted = false;
+			}
+
+			setCollapsed(root);
+			active = root;
+			active.highlighted = true;
+			render(root, options);
+		}
+		else if (key.ctrl) {
+			// Collapse the current group and all its subgroups
+			setCollapsed(active);
+			render(root, options);
+		}
+		else if (active.collapsed === false) {
+			active.collapsed = true;
+			render(root, options);
+		}
+		else if (active.parent) {
+			// Already collapsed — collapse the parent group instead
+			let groups = getNavigableGroups(root, options);
+			let index = groups.indexOf(active.parent);
+			active = groups[index];
+			active.collapsed = true;
+
+			for (let group of groups) {
+				group.highlighted = false;
+			}
+			active.highlighted = true;
+			render(root, options);
+		}
+	}
+	else if (name === "right") {
+		offset = 0; // expanding changes the layout — drop any intra-group scroll
+
+		if (key.ctrl && key.shift) {
+			// Expand all groups
+			setCollapsed(root, false);
+			render(root, options);
+		}
+		else if (key.ctrl) {
+			// Expand the current group and all its subgroups
+			setCollapsed(active, false);
+			render(root, options);
+		}
+		else if (active.collapsed === true) {
+			active.collapsed = false;
+			render(root, options);
+		}
+	}
+	else if (name === "o") {
+		let file = active.test?.file?.path;
+		if (file) {
+			try {
+				if (process.platform === "win32") {
+					execFileSync("cmd", ["/c", "start", "", file], { stdio: "inherit" });
+				}
+				else {
+					let command = process.platform === "darwin" ? "open" : "xdg-open";
+					execFileSync(command, ["--", file], { stdio: "inherit" });
+				}
+			}
+			catch {}
+			render(root, options);
+		}
+	}
+	else if (name === "h") {
+		hint.expanded = !hint.expanded;
+		render(root, options);
+	}
+	else if (name === "r") {
+		offset = 0;
+		rerun();
+	}
+	else {
+		// Quit: exit alt screen, print final tree, clean up
+		fullscreen.toggle(false);
+
+		let messages = root.toString(options);
+		let tree = getTree(messages).toString();
+		console.log(format(tree));
+
+		process.exit();
+	}
+}
+
+// Rendering + entry point
+
+function render (root, options) {
+	let messages = root.toString({ ...options, format: options.format ?? "rich" });
+
+	let highlight = {}; // where the highlighted group sits in the rendered tree, so the viewport can track it
+	let tree = format(getTree(messages, highlight).toString());
+
+	let terminalRows = line => Math.max(1, Math.ceil(stringWidth(line) / process.stdout.columns));
+
+	let header =
+		"\n" + hint.text + (options.watch ? "\n\n<b>Watching for file changes…</b>" : "") + "\n\n";
+	header = format(header);
+	let headerRows = header.split("\n").reduce((rows, line) => rows + terminalRows(line), 0) - 1;
+	let budget = Math.max(1, process.stdout.rows - headerRows);
+
+	let lines = tree.split("\n");
+	let heights = lines.map(terminalRows);
+
+	let highlightStart = highlight.line ?? 0;
+	let highlightEnd = highlight.end ?? highlightStart + 1;
+	let next = highlight.next ?? highlightEnd;
+	let parent = highlight.parent ?? -1;
+
+	let start,
+		end,
+		pinned = -1;
+
+	if (offset > 0) {
+		pinned = highlightStart;
+		let available = budget - heights[highlightStart] - 1;
+		start = Math.min(
+			highlightStart + offset,
+			Math.max(highlightStart, getViewportStart(heights, next, available)),
+		);
+		end = Math.max(Math.min(getViewportEnd(heights, start, available), next), start + 1);
+	}
+	else {
+		({ start, end } = getViewport({ heights, highlightStart, highlightEnd, scroll, budget }));
+
+		if (parent > 0 && parent < start && budget > heights[parent] + 1) {
+			pinned = parent;
+			({ start, end } = getViewport({
+				heights,
+				highlightStart,
+				highlightEnd,
+				scroll,
+				budget: budget - heights[parent] - 1,
+			}));
+		}
+	}
+
+	// Sticky parent header: when the highlighted group's parent scrolled off the top,
+	// pin it above the viewport so the user keeps context.
+	pinned = pinned < 0 ? "" : "\x1b[2m" + lines[pinned] + "\n ⋮\n";
+
+	scroll = start;
+	viewport = { highlightStart, next, start, end };
+
+	process.stdout.write(
+		ansiEscapes.cursorTo(0, 0) +
+			ansiEscapes.eraseScreen +
+			"\x1b[0m" + // consistent formatting: header at normal brightness
+			header +
+			pinned +
+			"\x1b[2m" + // consistent formatting: tree lines dim
+			lines.slice(start, end).join("\n"),
+	);
+}
+
+/**
+ * Roots already seen by {@link interactiveTree}. A new root triggers
+ * scroll reset and initial collapse; a known root preserves UI state.
+ * @type {WeakSet<object>}
+ */
+let initialized = new WeakSet();
+
+/**
+ * Interactive test results viewer.
+ * Called from `done()` on every test completion event in interactive mode.
+ * @param {object} root - The root TestResult.
+ * @param {object} options - Test runner options.
+ * @param {object} callbacks
+ * @param {Function} callbacks.rerun - Trigger a test re-run.
+ */
+export default function interactiveTree (root, options, { rerun }) {
+	if (keypressListener) {
+		process.stdin.off("keypress", keypressListener);
+		keypressListener = null;
+	}
+
+	if (subtrees) {
+		for (let { result, state } of subtrees) {
+			restoreState(result, state);
+		}
+		if (root.stats.pending === 0) {
+			subtrees = null;
+		}
+	}
+
+	if (!fullscreen.active) {
+		fullscreen.toggle(true);
+	}
+
+	if (!initialized.has(root)) {
+		scroll = 0;
+		offset = 0;
+		viewport = {};
+		setCollapsed(root); // all groups and console messages are collapsed by default
+		initialized.add(root);
+	}
+
+	if (resizeListener) {
+		process.stdout.off("resize", resizeListener);
+	}
+	resizeListener = () => render(root, options);
+	process.stdout.on("resize", resizeListener);
+
+	render(root, options);
+
+	if (root.stats.pending === 0 && !keypressListener) {
+		readline.emitKeypressEvents(process.stdin);
+		process.stdin.setRawMode(true); // handle keypress events instead of Node
+
+		let groups = getNavigableGroups(root, options);
+		if (groups.some(g => g.highlighted)) {
+			active = groups.find(g => g.highlighted);
+		}
+		else {
+			active = root;
+			root.highlighted = true;
+		}
+
+		render(root, options);
+
+		keypressListener = (_, key) => handleKeypress(root, options, rerun, key);
+		process.stdin.on("keypress", keypressListener);
+	}
+
+	if (root.stats.fail > 0) {
+		process.exitCode = 1;
+	}
+}
+
+// Cleanup
+
+process.on("exit", () => {
+	if (process.stdout.isTTY) {
+		fullscreen.toggle(false);
+	}
+});


### PR DESCRIPTION
## Problem

The interactive test viewer has several UX issues:

**Scroll pollution.** `log-update` writes to the main terminal buffer. npm output, prior commands, and the help hint all stay visible above the tree — the screen gets noisier with every re-run. Quitting leaves stale output behind.

**Broken wrapping.** The viewport budget assumed one terminal row per line. Lines with emoji, ANSI escapes, or wide characters wrap unpredictably — the tree overflows the terminal and pushes the hint off-screen.

**No paging for tall groups.** When a group's expanded content is taller than the viewport, the bottom is unreachable — the user can't scroll through it, only collapse and move on.

**Scroll jitter.** Navigating between nearby groups shifts the entire viewport because there's no stable scroll position — every render re-centers.

**No resize handling.** Resizing the terminal leaves a stale layout until the next keypress.

### Before (main)

npm output and the 7-line help hint permanently consume most of the terminal:

```
npm audit details...                      ← terminal noise
> htest.dev@0.0.27 test                   ← terminal noise

Use ↑ and ↓ arrow keys to navigate...    ← 7 lines of help, always visible
Use Ctrl+↑ and Ctrl+↓ to go to...
To expand or collapse...
Press Ctrl+Shift+→ and Ctrl+Shift+←...
Press o to open the source file...
Press r to re-run all tests...
Use any other key to quit...

▶︎ All tests ✅ 98/98 PASS               ← only a few lines left for the tree
```

## Solution

Extract the interactive viewer into `src/interactive-tree.js`.

### Alt screen buffer — clean surface, no scroll pollution

```
Press h to toggle help.

Watching for file changes…

▶︎ All tests ❌ 99/100 PASS 1/100 FAIL (6.9 ms) index.js
```

Full terminal height for the tree. No npm output, no stale text.

### Collapsible help — `h` to toggle

```
Use ↑ and ↓ to navigate groups, → and ← to expand/collapse.
Ctrl+↑/↓ — first/last in group. Ctrl+→/← — expand/collapse subgroups.
Ctrl+Shift+→/← — expand/collapse all.

o open source file · r re-run tests · any other key quit.

Watching for file changes…

▶︎ All tests ❌ 99/100 PASS 1/100 FAIL (6.9 ms) index.js
```

### Quit — alt screen exits, final tree prints to main terminal

```
> htest.dev@0.0.27 test
> bin/htest.js tests/index.js --watch

▽ All tests ❌ 99/100 PASS 1/100 FAIL (8.3 ms) index.js
 └─┬ ▼ Long error trace ❌ 1/2 PASS 1/2 FAIL long-errors.js
   └──  FAIL  Deep stack with long message ...
```

Results are preserved in the terminal's normal buffer — not lost when the alt screen exits.


### Other improvements

- **Viewport-aware scrolling** — proper column-width accounting via `string-width`
- **Stable scroll position** — viewport keeps the previous position, only shifts when the highlighted group would be off-screen
- **Paging through oversized groups** — up/down page through hidden content before advancing to the next group
- **Sticky parent header** — when the highlighted group's parent scrolls off the top, it's pinned above the viewport
- **Terminal resize** — reflows on `resize` event
- **Watch-mode UI state** — collapse/highlight state is preserved across `--watch` partial re-runs

<img width="751" height="853" alt="image" src="https://github.com/user-attachments/assets/5ec2322d-558b-45e7-9d5f-0c772f25896e" />

### Architecture

`node.js` is now purely the Node environment — file watching, module reloading, test execution. `done()` delegates entirely to `interactiveTree()` for the interactive path:

```js
interactiveTree(root, options, { rerun: () => rerun(options) });
```

The interactive module manages its own lifecycle: keypress attach/detach, fullscreen enter/exit, scroll state, and watch re-run state preservation.

### Dependencies

- Added: `ansi-escapes`, `string-width` — both were already transitive deps of `log-update`
- Removed: `log-update`
- Net result: **8 fewer packages** (464 → 456) since `log-update` pulled in `cli-cursor`, `restore-cursor`, `wrap-ansi`, and others that are no longer needed

Closes #7

## Test plan

- [x] `npm test -- --ci` passes (99/100 — 1 intentional fixture failure)
- [x] Interactive navigation: ↑↓ between groups, →← expand/collapse, Ctrl variants, Ctrl+Shift expand/collapse all
- [x] `h` toggles help hint
- [x] `o` opens source file
- [x] `r` re-runs, tree resets
- [x] `--watch` partial re-run preserves collapse/highlight state
- [x] Terminal resize reflows the view
- [x] Quit prints the final tree to the main terminal
- [x] Long wrapped lines (wide terminal → narrow) don't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)