### PR TITLE
In-flight progress feedback for long-running tests

### DIFF
--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -468,6 +468,13 @@ ${this.error.stack}`);
 	 * @returns {string}
 	 */
 	getResult (o) {
+		// In-flight: no result yet — render the animating icon and the name, nothing else.
+		if (this.pass === undefined && !this.skipped) {
+			let icon = o?.heartbeat ? "⌛" : "⏳";
+			let ret = `${icon} <dim>${this.name ?? "(Anonymous)"}</dim>`;
+			return o?.format === "rich" ? ret : stripFormatting(ret);
+		}
+
 		let color = this.pass ? "green" : this.skipped ? "yellow" : "red";
 		let label = this.pass ? "PASS" : this.skipped ? "SKIP" : "FAIL";
 		let ret = [
@@ -520,7 +527,7 @@ ${this.error.stack}`);
 			ret.push(`<dim><b>${stats.messages}</b> ${suffix}</dim>`);
 		}
 
-		let icon = stats.fail > 0 ? "❌" : stats.pending > 0 ? "⏳" : "✅";
+		let icon = stats.pending > 0 ? (o?.heartbeat ? "⌛" : "⏳") : stats.fail > 0 ? "❌" : "✅";
 		ret.splice(1, 0, icon);
 
 		if (this.timeTaken) {
@@ -571,6 +578,7 @@ ${this.error.stack}`);
 		}
 		else if (
 			!this.parent ||
+			(this.pass === undefined && !this.skipped) || // in-flight: render the leaf in expanded trees — else returns "" and the parent filters it out
 			this.pass === false ||
 			(this.skipped && (this.error || this.test.skip === "fail")) ||
 			this.messages?.length > 0 ||
@@ -581,7 +589,7 @@ ${this.error.stack}`);
 
 		ret = ret.join("\n");
 
-		if (this.tests || this.messages) {
+		if (this.tests || this.messages?.length > 0) {
 			ret = new String(ret);
 
 			if (this.tests) {

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -368,6 +368,16 @@ export default {
 
 		syncWatchers(options);
 	},
+	start (target, options, event, root) {
+		// `start` bubbles — skip descendants so we only fire once, on the root's own start.
+		if (options.signal?.aborted || !isInteractive || target !== root) {
+			return;
+		}
+
+		currentRoot = root;
+		// Open the interactive tree now so progress shows immediately — otherwise nothing renders until the first `done` event.
+		interactiveTree(root, options, { rerun: () => rerun(options) });
+	},
 	done (result, options, event, root) {
 		if (options.signal?.aborted) {
 			return;

--- a/src/interactive-tree.js
+++ b/src/interactive-tree.js
@@ -95,13 +95,15 @@ export function getTree (msg, highlight = {}, parent = -1, state = { line: 0, se
 	return new AsciiTree(`</dim>${msg}<dim>`, ...nodes);
 }
 
-export function setCollapsed (node, collapsed = true) {
+export function setCollapsed (node, collapsed = true, { keepExisting = false } = {}) {
 	if (node.tests?.length || node.messages?.length) {
-		node.collapsed = collapsed;
+		if (!keepExisting || node.collapsed === undefined) {
+			node.collapsed = collapsed;
+		}
 
 		let nodes = [...(node.tests ?? []), ...(node.messages ?? [])];
 		for (let node of nodes) {
-			setCollapsed(node, collapsed);
+			setCollapsed(node, collapsed, { keepExisting });
 		}
 	}
 }
@@ -161,6 +163,10 @@ let viewport;
 let active;
 
 let resizeListener, keypressListener;
+
+// Toggled each tick by the timer below; threaded into TestResult via `o.heartbeat` to alternate the ⏳/⌛ in-flight icon.
+let heartbeat = false;
+let heartbeatTimer;
 
 // Watch state
 
@@ -371,7 +377,7 @@ function handleKeypress (root, options, rerun, key) {
 // Rendering + entry point
 
 function render (root, options) {
-	let messages = root.toString({ ...options, format: options.format ?? "rich" });
+	let messages = root.toString({ ...options, format: options.format ?? "rich", heartbeat });
 
 	let highlight = {}; // where the highlighted group sits in the rendered tree, so the viewport can track it
 	let tree = format(getTree(messages, highlight).toString());
@@ -476,7 +482,6 @@ export default function interactiveTree (root, options, { rerun }) {
 		scroll = 0;
 		offset = 0;
 		viewport = {};
-		setCollapsed(root); // all groups and console messages are collapsed by default
 		initialized.add(root);
 	}
 
@@ -486,9 +491,11 @@ export default function interactiveTree (root, options, { rerun }) {
 	resizeListener = () => render(root, options);
 	process.stdout.on("resize", resizeListener);
 
+	setCollapsed(root, true, { keepExisting: true }); // default-collapse untouched groups (preserves user toggles)
+
 	render(root, options);
 
-	if (root.stats.pending === 0 && !keypressListener) {
+	if (!keypressListener) {
 		readline.emitKeypressEvents(process.stdin);
 		process.stdin.setRawMode(true); // handle keypress events instead of Node
 
@@ -505,6 +512,16 @@ export default function interactiveTree (root, options, { rerun }) {
 
 		keypressListener = (_, key) => handleKeypress(root, options, rerun, key);
 		process.stdin.on("keypress", keypressListener);
+	}
+
+	clearInterval(heartbeatTimer);
+
+	if (root.stats.pending > 0) {
+		heartbeatTimer = setInterval(() => {
+			heartbeat = !heartbeat;
+			setCollapsed(root, true, { keepExisting: true }); // default-collapse untouched groups (preserves user toggles)
+			render(root, options);
+		}, 1000);
 	}
 
 	if (root.stats.fail > 0) {


### PR DESCRIPTION
Closes #166.

Before this, the interactive CLI was dark from process start until the first `done` event. For a 10s slow test, that meant a full screen of nothing — indistinguishable from a hung process.

## What changed

- Animated heartbeat icon (⏳ ↔ ⌛) on in-flight groups and leaves, ticking once per second
- The interactive tree opens at run start (was: first `done` event), so users see *something* immediately
- Keypress navigation (↑/↓/←/→ and Ctrl/Shift variants) works during in-flight (was: only after all tests had finished)
<img width="699" height="195" alt="image" src="https://github.com/user-attachments/assets/6d3c5e3c-dd53-4ceb-90f7-4c0fd4e77b89" />

- In-flight leaves render `⏳ <name>` instead of dark "FAIL" (the `pass === undefined` lifecycle state was falling through the color/label ternary)
<img width="236" height="86" alt="SCR-20260621-lynn" src="https://github.com/user-attachments/assets/3e696bb6-6f31-4080-b508-808169db260c" />

- Pending wins over fail in the group icon priority — when some tests are still running, show ⏳ rather than ❌
<img width="729" height="150" alt="SCR-20260621-lyhh" src="https://github.com/user-attachments/assets/15b26422-05e6-4a61-94ab-4ee3c6026bdb" />

- `setCollapsed` gains a `{ keepExisting: true }` option so the render-time default-collapse can populate lazy-built subtrees without overriding user toggles
- Empty `messages` arrays no longer box leaves into ghost `└──` branches in the tree output

## CI mode is unchanged (by design)

CI/pipe mode stays silent until the final tree is printed. Matches Vitest's convention (no per-test stream, no heartbeat) — and even a `RUN` preamble doesn't really solve the "looks hung" perception, it just shifts it. CI runners and timestamps are the right tools for liveness in pipe mode.

## Test plan

- [x] Run a slow single test in interactive mode — heartbeat icon animates once per second
- [x] Run a multi-test suite in parallel — collapsed root summary shows `⏳ N/M remaining` with the animated icon
- [x] Expand a group during in-flight (`→`) — children appear; nested groups remain collapsed by default
- [x] Navigate during in-flight (↑/↓) — highlight moves; no escape sequences leak to the terminal
- [x] `--watch` mode: edit a test file during a slow run — the new tree renders correctly, no leftover content from the old run interleaves
- [x] `npm test` (CI mode) — output unchanged from main; 98/98 still pass