### PR TITLE
Test afterAll lifecycle and --ci completion

### DIFF
--- a/src/classes/TestResult.js
+++ b/src/classes/TestResult.js
@@ -188,7 +188,20 @@ export default class TestResult extends BubblingEventTarget {
 		this.stats.total = this.test.testCount;
 		this.stats.pending = this.stats.total;
 		this.finished = new Promise(resolve =>
-			this.addEventListener("finish", resolve, { once: true }));
+			this.addEventListener(
+				"finish",
+				async () => {
+					await Promise.allSettled((this.tests ?? []).map(t => t.finished));
+					if (!this.parent?.error) {
+						try {
+							await this.test.afterAll?.();
+						}
+						catch {}
+					}
+					resolve();
+				},
+				{ once: true },
+			));
 
 		let tests = this.test.tests;
 		let childOptions = Object.assign({}, this.options);
@@ -218,48 +231,38 @@ export default class TestResult extends BubblingEventTarget {
 
 		this.tests = this.test.tests?.map(t => new TestResult(t, this, childOptions));
 
-		delay(1)
-			.then(async () => {
-				let error = this.parent?.error;
+		delay(1).then(async () => {
+			let error = this.parent?.error;
 
-				if (!error && !this.options.signal?.aborted) {
-					try {
-						await this.test.beforeAll?.();
-					}
-					catch (e) {
-						e.source = "beforeAll";
-						error = e;
-					}
+			if (!error && !this.options.signal?.aborted) {
+				try {
+					await this.test.beforeAll?.();
 				}
+				catch (e) {
+					e.source = "beforeAll";
+					error = e;
+				}
+			}
 
-				if (error) {
-					this.error = error;
-				}
+			if (error) {
+				this.error = error;
+			}
 
-				if (this.test.isTest) {
-					if (this.test.skip && this.test.skip !== "fail") {
-						this.skip();
-					}
-					else if (error) {
-						this.details = [`${error.source}: ${error.message}`];
-						this.skip();
-					}
-					else {
-						this.run();
-					}
+			if (this.test.isTest) {
+				if (this.test.skip && this.test.skip !== "fail") {
+					this.skip();
 				}
+				else if (error) {
+					this.details = [`${error.source}: ${error.message}`];
+					this.skip();
+				}
+				else {
+					this.run();
+				}
+			}
 
-				return Promise.allSettled((this.tests ?? []).map(test => test.runAll()));
-			})
-			.then(() => this.finished)
-			.finally(async () => {
-				if (!this.parent?.error) {
-					try {
-						await this.test.afterAll?.();
-					}
-					catch {}
-				}
-			});
+			return Promise.allSettled((this.tests ?? []).map(test => test.runAll()));
+		});
 
 		return this;
 	}

--- a/src/env/node.js
+++ b/src/env/node.js
@@ -370,7 +370,20 @@ export default {
 	},
 	start (target, options, event, root) {
 		// `start` bubbles — skip descendants so we only fire once, on the root's own start.
-		if (options.signal?.aborted || !isInteractive || target !== root) {
+		if (options.signal?.aborted || target !== root) {
+			return;
+		}
+
+		if (!isInteractive) {
+			root.finished.then(() => {
+				let messages = root.toString(options);
+				let tree = getTree(messages).toString();
+				tree = process.stdout.isTTY ? format(tree) : stripFormatting(tree);
+
+				console[root.stats.fail > 0 ? "error" : "log"](tree);
+
+				process.exit(root.stats.fail > 0 ? 1 : 0);
+			});
 			return;
 		}
 
@@ -379,20 +392,7 @@ export default {
 		interactiveTree(root, options, { rerun: () => rerun(options) });
 	},
 	done (result, options, event, root) {
-		if (options.signal?.aborted) {
-			return;
-		}
-
-		if (!isInteractive) {
-			if (root.stats.pending === 0) {
-				let messages = root.toString(options);
-				let tree = getTree(messages).toString();
-				tree = process.stdout.isTTY ? format(tree) : stripFormatting(tree);
-
-				console[root.stats.fail > 0 ? "error" : "log"](tree);
-
-				process.exit(root.stats.fail > 0 ? 1 : 0);
-			}
+		if (options.signal?.aborted || !isInteractive) {
 			return;
 		}
 

--- a/tests/run.js
+++ b/tests/run.js
@@ -25,6 +25,68 @@ export default {
 			],
 		},
 		{
+			name: "afterAll lifecycle",
+			tests: [
+				{
+					name: "Runs at every level, bottom-up, before result.finished resolves",
+					async run () {
+						let ran = [];
+						let test = new Test({
+							afterAll: () => ran.push("root"),
+							tests: [
+								{
+									afterAll: () => ran.push("level1"),
+									tests: [
+										{
+											async afterAll () {
+												await new Promise(r => setTimeout(r, 50));
+												ran.push("level2");
+											},
+											tests: [
+												{ run: () => "foo", expect: "foo" },
+												{ run: () => "bar", expect: "bar" },
+											],
+										},
+									],
+								},
+							],
+						});
+						let result = new TestResult(test, null);
+						result.runAll();
+						await result.finished;
+						return ran;
+					},
+					expect: ["level2", "level1", "root"],
+				},
+				{
+					name: "Completes before process.exit in --ci mode (issue #168)",
+					skip: typeof globalThis.process === "undefined",
+					async run () {
+						let { spawnSync } = await import("node:child_process");
+						let { writeFileSync, rmSync } = await import("node:fs");
+						let { tmpdir } = await import("node:os");
+						let { join } = await import("node:path");
+
+						let fixture = join(tmpdir(), "htest-168.js");
+						writeFileSync(
+							fixture,
+							`export default { async afterAll () { await new Promise(r => setTimeout(r, 50)); process.stderr.write("[test] afterAll ran"); }, tests: [{ run: () => 1, expect: 1 }] };`,
+						);
+
+						let { stderr } = spawnSync(
+							process.execPath,
+							[join(process.cwd(), "bin/htest.js"), fixture, "--ci"],
+							{ encoding: "utf8" },
+						);
+						rmSync(fixture);
+
+						return stderr.includes("[test] afterAll ran");
+					},
+					expect: true,
+				},
+			],
+		},
+		{
 			name: "Aborting",
 			tests: [
 				{


### PR DESCRIPTION
Stacks on #170.

Two-layer regression coverage for #168:

- **Unit** (`Runs at every level, bottom-up, before result.finished resolves`) — pins the `TestResult` finish-listener contract. 3-level nested afterAll with mixed sync/async; asserts bottom-up push order.
- **E2E** (`Completes before process.exit in --ci mode (issue #168)`) — spawns `node bin/htest.js fixture.js --ci` in a subprocess; the fixture's async `afterAll` writes `[test] afterAll ran` to stderr, captured and asserted on. Catches env-layer regressions the unit test can't.

Verified by reverting each fix in isolation:
- Revert `TestResult.js` → unit fails (`Got ["level1", "root"], expected ["level2", "level1", "root"]`).
- Revert `env/node.js` → e2e fails (`Got false, expected true`); unit still passes (independent coverage confirmed).

## Test plan

- [x] CI passes