### PR TITLE
Document beforeAll/afterAll ordering in nested groups

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -157,6 +157,8 @@ export default {
 | `beforeEach` / `afterEach` | Run before/after each test. Called like `run` — same `this`, same arguments. Inherited. Sync or async |
 | `beforeAll` / `afterAll`   | Run before/after all tests in the group where defined. Called with no arguments. **Not inherited** |
 
+In nested groups, `beforeAll` runs top-down (parent → child) and `afterAll` runs bottom-up (child → parent); async cleanup is awaited before the next level fires.
+
 A child that defines its own `beforeEach`/`afterEach` **overrides** the parent's — they are not chained automatically.
 
 To invoke the parent's hook from a child override, call `this.parent.beforeEach()` (or whichever hook). You control where the parent's logic runs — before, after, or in the middle of the child's:

--- a/docs/define/README.md
+++ b/docs/define/README.md
@@ -85,6 +85,10 @@ This gives you full control over where the parent's logic runs — before your o
 }
 ```
 
+#### Ordering
+
+In nested groups, `beforeAll` runs **top-down** — the outermost group's setup runs first, then its children's. `afterAll` runs **bottom-up** — the innermost group's teardown completes (including any async work) before its parent's starts. This matches the convention in Jest, Vitest, and Mocha.
+
 #### Error handling
 
 If a hook throws, the test is **skipped** — not failed.


### PR DESCRIPTION
Stacks on #171.

Documents the ordering contract formalized by #170:

- **`docs/define/README.md`** — new `#### Ordering` subsection under Lifecycle hooks: `beforeAll` runs top-down, `afterAll` runs bottom-up (matches Jest/Vitest/Mocha).
- **`SKILL.md`** — one sentence after the lifecycle table.

Pre-existing `beforeAll` ordering (top-down) verified empirically alongside the new `afterAll` ordering (bottom-up); a single 20-line script with mixed sync/async hooks at each level produced `["before:root", "before:level1", "before:level2", "after:level2", "after:level1", "after:root"]`.

Generated `docs/**/index.html` will regenerate on next `npm run build` — not included in this PR.

## Test plan

- [x] Render the docs site locally (`npm run dev`) and visually confirm the new subsection