### PR TITLE
Refactor CLI to schema-driven parseArgs

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,47 +1,61 @@
 #!/usr/bin/env node
+import process from "node:process";
 import env from "./env/node.js";
 import run from "./run.js";
 import { getConfig, loadScripts } from "./config.js";
+import { parseArgs, mergeOptions, USAGE_HINT, formatHelp, getVersion } from "./util/options.js";
 
 /**
- * Run tests via a CLI command
- * First argument is the location to look for tests (defaults to the current directory)
- * Second argument is the test path (optional)
+ * Run tests via the CLI or programmatically.
  *
- * Supported flags:
- * --ci         Run in continuous integration mode (disables interactive features)
- * --verbose    Verbose output (show all tests, not just failed, skipped, or tests with intercepted console messages)
- * --watch      Watch the test location for file changes and re-run automatically
- *
- * @param {object} [options] Same as `run()` options, but command line arguments take precedence
+ * @param {object | string} [test] Test object, array of tests, or location string. When omitted,
+ *   the runner resolves a location from CLI positionals, `options.location`, config, or env defaults.
+ * @param {object} [options] Programmatic options, merged underneath CLI flags and positionals
+ *   but on top of the config file. Same shape as `run()` options.
  */
-export default async function cli (options = {}) {
-	let config = await getConfig();
-	if (config) {
-		options = { ...config, ...options };
-	}
+export default async function cli (test, options = {}) {
+	try {
+		let { values: flags, positionals } = parseArgs(process.argv.slice(2));
 
-	let argv = process.argv.slice(2);
-
-	const flags = ["ci", "verbose", "watch"];
-	for (let flag of flags) {
-		let flagIndex = argv.indexOf("--" + flag);
-		if (flagIndex !== -1) {
-			argv.splice(flagIndex, 1); // remove the flag from args
-			options[flag] = true;
+		if (flags.help) {
+			console.log(formatHelp());
+			return;
 		}
+
+		if (flags.version) {
+			console.log(await getVersion());
+			return;
+		}
+
+		let config = await getConfig(flags.config);
+		let hasTest = test != null;
+
+		// Bare `htest` (no test, no argv, no config) — nudge instead of running an empty cwd.
+		if (!hasTest && process.argv.length <= 2 && !config) {
+			console.log(USAGE_HINT);
+			return;
+		}
+
+		// `run()` accepts a string OR test object/array as its first arg, so a `test`-as-location
+		// layer flows through unchanged when nothing else sets it.
+		if (hasTest) {
+			options = { ...options, location: test };
+		}
+		let {
+			location,
+			setup,
+			config: _,
+			...rest
+		} = mergeOptions(config, options, positionals, flags);
+
+		if (setup) {
+			await loadScripts(setup);
+		}
+
+		run(location, { env, ...rest });
 	}
-
-	if (options.setup) {
-		await loadScripts(options.setup);
-		delete options.setup;
+	catch (err) {
+		console.error(`[htest] ${err.message}`);
+		process.exitCode = 1;
 	}
-
-	let location = argv[0];
-
-	if (argv[1]) {
-		options.path = argv[1];
-	}
-
-	run(location, { env, ...options });
 }

--- a/src/config.js
+++ b/src/config.js
@@ -5,6 +5,14 @@ import { globSync } from "glob";
 const CONFIG_GLOB = "{,_,.}htest.{json,config.json,config.js}";
 let config;
 
+/**
+ * Load the project's htest config.
+ *
+ * @param {string} [glob] Glob pattern (a literal file path is a degenerate glob that matches itself).
+ *   Throws on no-match when explicit so a typo doesn't get swallowed; silently returns on no-match
+ *   for the default discovery pattern (a project just doesn't have a config).
+ * @returns {Promise<object | undefined>} The config object, or `undefined` if no config exists.
+ */
 export async function getConfig (glob = CONFIG_GLOB) {
 	if (config) {
 		return config;
@@ -12,18 +20,16 @@ export async function getConfig (glob = CONFIG_GLOB) {
 
 	let paths = globSync(glob);
 
-	if (paths.length > 0) {
-		let configPath = "./" + paths[0];
-		let importParams;
-		configPath = path.join(process.cwd(), configPath);
-		if (configPath.endsWith(".json")) {
-			importParams = { assert: { type: "json" }, with: { type: "json" } };
+	if (paths.length === 0) {
+		if (glob !== CONFIG_GLOB) {
+			throw new Error(`Config file not found: ${glob}`);
 		}
-
-		config = await import(configPath, importParams).then(m => (config = m.default));
-
-		return config;
+		return;
 	}
+
+	let configPath = path.resolve(paths[0]);
+	let importParams = configPath.endsWith(".json") ? { with: { type: "json" } } : undefined;
+	return (config = (await import(configPath, importParams)).default);
 }
 
 export async function loadScripts (scripts) {

--- a/src/util/options.js
+++ b/src/util/options.js
@@ -1,0 +1,220 @@
+import { parseArgs as nodeParseArgs } from "node:util";
+
+const USAGE = "Usage: htest [<test-location> [<test-path>]] [options]";
+
+export const USAGE_HINT = `${USAGE}
+
+To get started:
+  • Run your tests: htest tests/
+  • Create htest.config.js for project defaults
+  • See all options: htest --help`;
+
+/**
+ * Schema for every CLI-overridable option. Key = CLI flag name = `run()` option key.
+ *
+ * Pass straight to `parseArgs` — it reads `type`/`short`/`multiple` and ignores the rest.
+ * Do NOT add `default` here: parseArgs honors it and would inject the value on every flag-less
+ * run, silently overriding config. Runtime defaults live in `src/env/node.js` and `src/run.js`;
+ * mention them in `description` if useful for `--help`.
+ *
+ * Metadata fields consumed by `parseArgs`/`formatHelp` only:
+ * - `description` — right-column text in `--help`.
+ * - `values: [...]` — enum. Rendered as `<a|b|c>` and enforced (invalid values throw).
+ * - `placeholder` — value hint when `values` is absent (e.g. `<path>`).
+ *
+ * Declaration order = `--help` row order.
+ */
+const OPTIONS = {
+	// Test selection
+	location: {
+		type: "string",
+		placeholder: "<path>",
+		description: "Where to find tests: a file, directory, or glob",
+	},
+	path: {
+		type: "string",
+		placeholder: "<test-path>",
+		description: "Run a single test by its position, e.g. 0/2 (3rd test of the 1st group)",
+	},
+	only: {
+		type: "string",
+		multiple: true,
+		placeholder: "<id|position>",
+		description:
+			"Run only the test with this id or at this position. Pass multiple times to combine",
+	},
+
+	// Runtime behavior
+	ci: {
+		type: "boolean",
+		description: "CI mode: non-interactive, exits with an error code if any test fails",
+	},
+	watch: {
+		type: "boolean",
+		short: "w",
+		description: "Re-run tests when test or source files change",
+	},
+	verbose: {
+		type: "boolean",
+		short: "V",
+		description: "Show all test results, including passing ones",
+	},
+
+	// Output
+	format: {
+		type: "string",
+		short: "f",
+		values: ["rich", "plain"],
+		description: "Output format (default: rich)",
+	},
+	env: {
+		type: "string",
+		short: "e",
+		values: ["auto", "node", "console"],
+		description: "Test environment (default: auto)",
+	},
+
+	// Config / setup
+	config: {
+		type: "string",
+		short: "c",
+		placeholder: "<path>",
+		description: "Load this config file instead of searching for one",
+	},
+	setup: {
+		type: "string",
+		short: "s",
+		multiple: true,
+		placeholder: "<path>",
+		description: "Script to run before tests. Pass multiple times to run several",
+	},
+
+	// Meta. Note: -v is --version (the widespread default); -V is --verbose. parseArgs is case-sensitive.
+	help: {
+		type: "boolean",
+		short: "h",
+		description: "Show this help message",
+	},
+	version: {
+		type: "boolean",
+		short: "v",
+		description: "Show the version",
+	},
+};
+
+/**
+ * Parse CLI arguments against the OPTIONS schema. Thin superset of `node:util` `parseArgs`:
+ * same return shape, plus enum-value validation and a max-positionals cap. All errors carry
+ * an `HTEST_*` code and a self-contained, single-sentence message.
+ *
+ * @param {string[]} argv Arguments to parse (typically `process.argv.slice(2)`).
+ * @returns {{ values: object, positionals: string[] }}
+ */
+export function parseArgs (argv) {
+	let result;
+	try {
+		result = nodeParseArgs({
+			args: argv,
+			options: OPTIONS,
+			allowPositionals: true,
+			strict: true,
+		});
+	}
+	catch (err) {
+		if (err.code === "ERR_PARSE_ARGS_UNKNOWN_OPTION") {
+			let e = new Error(`Unknown option. Run "htest --help" for available options.`);
+			e.code = "HTEST_UNKNOWN_OPTION";
+			throw e;
+		}
+		if (err.code === "ERR_PARSE_ARGS_INVALID_OPTION_VALUE") {
+			let e = new Error(`Invalid option value. Run "htest --help" for usage.`);
+			e.code = "HTEST_INVALID_OPTION_VALUE";
+			throw e;
+		}
+		throw err;
+	}
+
+	for (let [key, value] of Object.entries(result.values)) {
+		let values = OPTIONS[key]?.values;
+		if (values && !values.includes(value)) {
+			let err = new Error(
+				`Invalid value for --${key}: ${value}. Expected one of: ${values.join(", ")}.`,
+			);
+			err.code = "HTEST_INVALID_VALUE";
+			throw err;
+		}
+	}
+
+	if (result.positionals.length > 2) {
+		let err = new Error(
+			`Too many arguments: ${result.positionals.join(" ")}. Expected at most 2 — a test location and an optional test path.`,
+		);
+		err.code = "HTEST_TOO_MANY_ARGS";
+		throw err;
+	}
+
+	return result;
+}
+
+/**
+ * Merge the precedence layers into one options object.
+ * Order (low → high): `config < options < positionals < flags`. Programmatic options sit between
+ * config and positionals; positionals beat them both but lose to explicit CLI flags.
+ * Pure — no I/O. Any layer may be `undefined`.
+ *
+ * The `positionals[N] !== undefined` guards avoid creating `location: undefined` / `path: undefined`
+ * keys (which would shadow `env.defaultOptions` downstream).
+ *
+ * @param {object | undefined} config Config-file values (lowest priority).
+ * @param {object | undefined} options Programmatic `cli(test, options)` values.
+ * @param {string[]} positionals CLI positional arguments — `[0]` fills `location`, `[1]` fills `path`.
+ * @param {object} flags CLI flag values from `parseArgs` (highest priority).
+ * @returns {object} The merged options object.
+ */
+export function mergeOptions (config, options, positionals, flags) {
+	let merged = { ...config, ...options };
+	if (positionals[0] !== undefined) {
+		merged.location = positionals[0];
+	}
+	if (positionals[1] !== undefined) {
+		merged.path = positionals[1];
+	}
+	return { ...merged, ...flags };
+}
+
+/**
+ * Render the help string from OPTIONS. Each row shows the flag (with short alias if any) and a
+ * value hint derived from `values` / `placeholder`.
+ *
+ * @returns {string}
+ */
+export function formatHelp () {
+	let rows = Object.entries(OPTIONS).map(([key, option]) => {
+		let flag = (option.short ? `-${option.short}, ` : "    ") + `--${key}`;
+		if (option.type === "string") {
+			flag += ` ${option.values ? `<${option.values.join("|")}>` : (option.placeholder ?? "<value>")}`;
+		}
+		return { flag, description: option.description };
+	});
+
+	let width = Math.max(...rows.map(row => row.flag.length));
+
+	return [
+		USAGE,
+		"",
+		"Options:",
+		...rows.map(row => `  ${row.flag.padEnd(width)}  ${row.description}`),
+	].join("\n");
+}
+
+/**
+ * Read the package version from package.json.
+ * package.json is always shipped by npm regardless of the `files` field, so the relative path
+ * resolves in both source-tree and npm-installed layouts.
+ *
+ * @returns {Promise<string>}
+ */
+export async function getVersion () {
+	let pkg = (await import("../../package.json", { with: { type: "json" } })).default;
+	return pkg.version;
+}


### PR DESCRIPTION
Replaces hand-rolled flag parsing in cli.js with node:util parseArgs driven by an OPTIONS schema in src/util/options.js. Adds --help, --version, --config, --format, --env, --only, plus short aliases. Graceful single-line errors. Bare `htest` prints a usage hint when no config is found.

The `cli(test, options)` programmatic API is preserved.

Closes #21.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #175
- <kbd>&nbsp;1&nbsp;</kbd> #174 👈 
<!-- GitButler Footer Boundary Bottom -->