### PR TITLE
Document new CLI options surface

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -454,7 +454,9 @@ tests: rawCases.map(c => ({ ...c, expect: referenceImpl(c.arg) })),
 
 ## Configuration
 
-Optional. hTest looks for `{,_,.}htest.{json,config.json,config.js}` in the project root. Accepts any CLI flag (`ci`, `verbose`) or runner option as a property; CLI flags override config values.
+Optional. hTest looks for `{,_,.}htest.{json,config.json,config.js}` in the project root, or use `--config <path>` to load one explicitly. Every CLI flag maps 1:1 to a config key of the same name; CLI flags override config values.
+
+Config keys: `location`, `path`, `only`, `ci`, `watch`, `verbose`, `format` (`"rich"` or `"plain"`), `env` (`"auto"`, `"node"`, `"console"`), `setup`.
 
 ### `setup` — Pre-Test Scripts
 
@@ -476,12 +478,20 @@ export default {
 ## Running Tests
 
 ```bash
-npx htest test/file.js       # Single file
-npx htest test/               # All JS in directory (not recursive, skips index*)
-npx htest test/index.js       # Use index files for recursive aggregation
-npx htest test/file.js --ci       # Force non-interactive mode (automatic in non-TTY environments)
-npx htest test/file.js --verbose  # Show all tests, including passing
-npx htest test/file.js --watch    # Re-run automatically on file changes
+npx htest test/file.js                  # Single file
+npx htest test/                         # All JS in directory (not recursive, skips index*)
+npx htest test/index.js                 # Use index files for recursive aggregation
+npx htest test/file.js 0/1              # Run only the test at this position (positional)
+npx htest test/file.js --only myTestId  # Run only the test with this id (or position); pass multiple times to combine
+npx htest test/file.js --ci             # Force non-interactive mode (automatic in non-TTY environments)
+npx htest test/file.js --verbose        # Show all tests, including passing (-V short)
+npx htest test/file.js --watch          # Re-run automatically on file changes (-w short)
+npx htest test/file.js --format plain   # Plain output instead of rich (-f short)
+npx htest test/file.js --env node       # Force a specific environment (-e short)
+npx htest test/file.js --config ./my.config.js  # Load a specific config file (-c short)
+npx htest test/file.js --setup ./hooks.js       # Run a setup script first; pass multiple times to run several (-s short)
+npx htest --help                        # List every flag (-h short)
+npx htest --version                     # Print version (-v short)
 ```
 
 ---

--- a/docs/run/node/README.md
+++ b/docs/run/node/README.md
@@ -116,7 +116,7 @@ run("tests/*.js");
 
 ## Configuration
 
-Create `htest.config.js` in your project root (dotfile and JSON variants also supported). Any CLI option (`ci`, `verbose`) or runner option (`format`) can be set here. CLI flags override config values.
+Create `htest.config.js` in your project root (dotfile and JSON variants also supported). Any option from the [Options reference](#options-reference) below can be set here. CLI flags override config values.
 
 ```js
 export default {
@@ -137,6 +137,25 @@ Import one or more scripts before any test file is loaded. Useful for polyfills,
 Scripts are imported sequentially (later entries may depend on earlier ones). Paths resolve relative to the current working directory.
 
 Each entry is a path string or an object with `src` and optional `loadIf`. If `loadIf` is `false`, the script is skipped.
+
+## Options reference
+
+Every CLI flag maps 1:1 to a config file key of the same name. CLI flags override config values; config values override hard defaults.
+
+| Option         | Config key | CLI flag                       | Short | Default                | Description                                                                       |
+| -------------- | ---------- | ------------------------------ | ----- | ---------------------- | --------------------------------------------------------------------------------- |
+| Test location  | `location` | `--location <path>`            | —     | `process.cwd()`        | A directory, file, or glob. Also accepted as the 1st positional argument.         |
+| Test path      | `path`     | `--path <test-path>`           | —     | —                      | Run a single test by its position. Slash-separated 0-based indices, e.g. `0/2` for the 3rd test of the 1st group. Also accepted as the 2nd positional. |
+| Only           | `only`     | `--only <id\|position>`        | —     | —                      | Run only the test with this `id` or at this 0-based position. Pass multiple times to combine, e.g. `--only 0 --only myTestId` runs `myTestId` inside the first group. |
+| CI mode        | `ci`       | `--ci`                         | —     | `false`                | Non-interactive. Exits with an error code if any test fails.                      |
+| Watch          | `watch`    | `--watch`                      | `-w`  | `false`                | Re-run when test or source files change.                                          |
+| Verbose        | `verbose`  | `--verbose`                    | `-V`  | `false`                | Show all test results, including passing ones.                                    |
+| Output format  | `format`   | `--format <rich\|plain>`       | `-f`  | `rich`                 | Output format.                                                                    |
+| Environment    | `env`      | `--env <auto\|node\|console>`  | `-e`  | `auto`                 | Where tests run.                                                                  |
+| Config file    | —          | `--config <path>`              | `-c`  | (found automatically)  | Load this config file instead of searching for one. CLI-only — can't be set in a config (chicken-and-egg). |
+| Setup scripts  | `setup`    | `--setup <path>`               | `-s`  | —                      | Script to run before tests. Pass multiple times to run several. CLI accepts paths only; the config form accepts `{ src, loadIf }` objects too. |
+| Help           | —          | `--help`                       | `-h`  | —                      | Show the help message.                                                            |
+| Version        | —          | `--version`                    | `-v`  | —                      | Show the version.                                                                 |
 
 ## Interactive mode
 


### PR DESCRIPTION
Adds an Options reference table to `docs/run/node/README.md`. Updates `SKILL.md` Configuration and Running Tests sections to reflect the new flags (`--help`, `--version`, `--config`, `--format`, `--env`, `--only`) and short aliases.

Stacked on #175.